### PR TITLE
WIP: Cleanup of handlers/urls

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -150,8 +150,8 @@ class Voila(Application):
         handlers = []
 
         handlers.extend([
-            (url_path_join(base_url, r'/api/kernels/%s' % _kernel_id_regex), KernelHandler),
-            (url_path_join(base_url, r'/api/kernels/%s/channels' % _kernel_id_regex), ZMQChannelsHandler),
+            (url_path_join(base_url, r'/voila/api/kernels/%s' % _kernel_id_regex), KernelHandler),
+            (url_path_join(base_url, r'/voila/api/kernels/%s/channels' % _kernel_id_regex), ZMQChannelsHandler),
             (
                 url_path_join(base_url, r'/voila/static/(.*)'),
                 tornado.web.StaticFileHandler,

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -18,10 +18,6 @@ from .paths import NBCONVERT_TEMPLATE_ROOT
 
 
 class VoilaHandler(JupyterHandler):
-    @property
-    def kernel_manager(self):
-        return self.settings['voila_kernel_manager']
-
     def initialize(self, notebook_path=None, strip_sources=True, custom_template_path=None):
         self.notebook_path = notebook_path
         self.strip_sources = strip_sources
@@ -29,7 +25,7 @@ class VoilaHandler(JupyterHandler):
         if custom_template_path:
             self.template_path.insert(0, custom_template_path)
 
-    # @tornado.web.authenticated
+    @tornado.web.authenticated
     @tornado.gen.coroutine
     def get(self, path=None):
         if path:

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -18,6 +18,10 @@ from .paths import NBCONVERT_TEMPLATE_ROOT
 
 
 class VoilaHandler(JupyterHandler):
+    @property
+    def kernel_manager(self):
+        return self.settings['voila_kernel_manager']
+
     def initialize(self, notebook_path=None, strip_sources=True, custom_template_path=None):
         self.notebook_path = notebook_path
         self.strip_sources = strip_sources
@@ -25,7 +29,7 @@ class VoilaHandler(JupyterHandler):
         if custom_template_path:
             self.template_path.insert(0, custom_template_path)
 
-    @tornado.web.authenticated
+    # @tornado.web.authenticated
     @tornado.gen.coroutine
     def get(self, path=None):
         if path:

--- a/voila/nbconvert_templates/base.tpl
+++ b/voila/nbconvert_templates/base.tpl
@@ -18,7 +18,7 @@
 
 <script id="jupyter-config-data" type="application/json">
 {
-    "baseUrl": "{{resources.base_url}}",
+    "baseUrl": "{{resources.base_url}}voila/",
     "kernelId": "{{resources.kernel_id}}"
 }
 </script>

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -17,11 +17,6 @@ from jinja2 import Environment, FileSystemLoader
 
 from jupyter_server.utils import url_path_join
 from jupyter_server.base.handlers import path_regex
-from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
-from jupyter_server.services.kernels.handlers import KernelHandler, ZMQChannelsHandler
-
-from jupyter_client.jsonutil import date_default
-from ipython_genutils.py3compat import cast_unicode
 
 from .paths import ROOT, TEMPLATE_ROOT, STATIC_ROOT
 from .handler import VoilaHandler
@@ -29,7 +24,6 @@ from .treehandler import VoilaTreeHandler
 from .app import base_handlers
 from .utils import add_base_url_to_handlers
 
-from tornado import gen, web
 
 def load_jupyter_server_extension(server_app):
     web_app = server_app.web_app
@@ -53,7 +47,7 @@ def load_jupyter_server_extension(server_app):
             'shutdown_request'
         ]
     )
-    web_app.settings['voila_kernel_manager'] = kernel_mapping_manager
+    web_app.settings['kernel_manager'] = kernel_mapping_manager
 
     host_pattern = '.*$'
     base_url = url_path_join(web_app.settings['base_url'])
@@ -63,5 +57,4 @@ def load_jupyter_server_extension(server_app):
         ('/voila/tree' + path_regex, VoilaTreeHandler),
         ('/voila/static/(.*)',  tornado.web.StaticFileHandler, {'path': str(STATIC_ROOT)})
     ] + base_handlers
-    print(add_base_url_to_handlers(base_url, base_handlers))
     web_app.add_handlers(host_pattern, add_base_url_to_handlers(base_url, handlers))

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -9,16 +9,54 @@
 import os
 import gettext
 from pathlib import Path
+import tempfile
+import json
 
 import tornado.web
 from jinja2 import Environment, FileSystemLoader
 
 from jupyter_server.utils import url_path_join
 from jupyter_server.base.handlers import path_regex
+from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
+from jupyter_server.services.kernels.handlers import KernelHandler, ZMQChannelsHandler
+
+from jupyter_client.jsonutil import date_default
+from ipython_genutils.py3compat import cast_unicode
 
 from .paths import ROOT, TEMPLATE_ROOT, STATIC_ROOT
 from .handler import VoilaHandler
 from .treehandler import VoilaTreeHandler
+from .app import _kernel_id_regex
+
+from tornado import gen, web
+
+class VoilaNotebookKernelManager(KernelHandler):
+    @property
+    def kernel_manager(self):
+        return self.settings['voila_kernel_manager']
+
+    # @web.authenticated
+    def get(self, kernel_id):
+        km = self.kernel_manager
+        km._check_kernel_id(kernel_id)
+        model = km.kernel_model(kernel_id)
+        self.finish(json.dumps(model, default=date_default))
+
+    # @web.authenticated
+    @gen.coroutine
+    def delete(self, kernel_id):
+        km = self.kernel_manager
+        yield gen.maybe_future(km.shutdown_kernel(kernel_id))
+        self.set_status(204)
+        self.finish()
+
+class VoilaNotebookZMQChannelsHandler(ZMQChannelsHandler):
+    def get_current_user(self):
+        return "voila"  # bypass AuthenticatedZMQStreamHandler's security handling
+
+    @property
+    def kernel_manager(self):
+        return self.settings['voila_kernel_manager']
 
 def load_jupyter_server_extension(server_app):
     web_app = server_app.web_app
@@ -30,6 +68,20 @@ def load_jupyter_server_extension(server_app):
     nbui = gettext.translation('nbui', localedir=str(ROOT / 'i18n'), fallback=True)
     env.install_gettext_translations(nbui, newstyle=False)
 
+    connection_dir = tempfile.gettempdir()
+
+    kernel_mapping_manager = MappingKernelManager(
+        connection_dir=connection_dir,
+        allowed_message_types=[
+            'comm_msg',
+            'comm_info_request',
+            'kernel_info_request',
+            'custom_message',
+            'shutdown_request'
+        ]
+    )
+    web_app.settings['voila_kernel_manager'] = kernel_mapping_manager
+
     host_pattern = '.*$'
     base_url = url_path_join(web_app.settings['base_url'])
     web_app.add_handlers(host_pattern, [
@@ -37,4 +89,9 @@ def load_jupyter_server_extension(server_app):
         (url_path_join(base_url, '/voila'), VoilaTreeHandler),
         (url_path_join(base_url, '/voila/tree' + path_regex), VoilaTreeHandler),
         (url_path_join(base_url, '/voila/static/(.*)'),  tornado.web.StaticFileHandler, {'path': str(STATIC_ROOT)})
+    ])
+
+    web_app.add_handlers(host_pattern, [
+        (url_path_join(base_url, r'/voila/api/kernels/%s' % _kernel_id_regex), VoilaNotebookKernelManager),
+        (url_path_join(base_url, r'/voila/api/kernels/%s/channels' % _kernel_id_regex), VoilaNotebookZMQChannelsHandler),
     ])

--- a/voila/utils.py
+++ b/voila/utils.py
@@ -1,0 +1,13 @@
+#############################################################################
+# Copyright (c) 2018, Voila Contributors                                    #
+#                                                                           #
+# Distributed under the terms of the BSD 3-Clause License.                  #
+#                                                                           #
+# The full license is in the file LICENSE, distributed with this software.  #
+#############################################################################
+
+from jupyter_server.utils import url_path_join
+
+def add_base_url_to_handlers(base_url, handlers):
+    """Adds the base_url in front of the urls in the Tornado handlers"""
+    return [tuple([url_path_join(base_url, url)] + list(tail)) for url, *tail in handlers]


### PR DESCRIPTION
For voila, I think it does not make sense (at least by default, or optional) to have authentication. At least to have a different behaviour for the notebook and the voila server extension.

What this allows, is to have a notebook server (normal authentication) but serve notebooks via voila without. This is very much a proof of concept and deserves more consideration. It exposes some of the issues that with notebook/jupyter_server has when you want to do this. For instance, to make `ZMQChannelsHandler` not check auth, we need to return a fake user. 

I think in general, voila shakes the box a bit, because instead of exposing kernels/notebooks as a security issue, now all of the sudden a kernel can be safe to expose (since it does not allow execution). Also to keep in mind is that multiuser all of the sudden makes sense.

Long term vision/idea: You could have a notebook run under your account, it ran a simulation or report for ~2 hours. Now users can connect to voila, they just want to see this report, which can be without authentication, or with authentication that has nothing to do with the notebook authentication.

