### PR TITLE
Expose HTMLExporter configuration

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -169,7 +169,8 @@ class Voila(Application):
                 {
                     'notebook_path': self.notebook_path,
                     'strip_sources': self.strip_sources,
-                    'custom_template_path': self.custom_template_path
+                    'custom_template_path': self.custom_template_path,
+                    'config': self.config
                 }
             ))
         else:

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -33,7 +33,9 @@ def load_jupyter_server_extension(server_app):
     host_pattern = '.*$'
     base_url = url_path_join(web_app.settings['base_url'])
     web_app.add_handlers(host_pattern, [
-        (url_path_join(base_url, '/voila/render' + path_regex), VoilaHandler),
+        (url_path_join(base_url, '/voila/render' + path_regex), VoilaHandler, {
+            'config': server_app.config
+        }),
         (url_path_join(base_url, '/voila'), VoilaTreeHandler),
         (url_path_join(base_url, '/voila/tree' + path_regex), VoilaTreeHandler),
         (url_path_join(base_url, '/voila/static/(.*)'),  tornado.web.StaticFileHandler, {'path': str(STATIC_ROOT)})


### PR DESCRIPTION
Fixes #24 

This allows specifying any HTMLExporter configuration with the command line for voila, as well as the notebook and jupyter_server extensions.

For example, to exclude markdown cells:

```
voila basics.ipynb --HTMLExporter.exclude_markdown=True
```

cc @DougRzz 