### PR TITLE
Add voila button for classical notebook, ala appmode

### DIFF
--- a/etc/jupyter/nbconfig/notebook.d/voila.json
+++ b/etc/jupyter/nbconfig/notebook.d/voila.json
@@ -1,0 +1,5 @@
+{
+    "load_extensions": {
+      "voila/nbextension": true
+    }
+}

--- a/voila/__init__.py
+++ b/voila/__init__.py
@@ -6,3 +6,9 @@
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
 
+def _jupyter_nbextension_paths():
+    return [dict(
+        section="notebook",
+        src="static",
+        dest="voila",
+        require="voila/nbextension")]

--- a/voila/static/nbextension.js
+++ b/voila/static/nbextension.js
@@ -1,0 +1,21 @@
+define(['jquery', 'base/js/namespace'], function($, Jupyter) {
+    "use strict";
+    var open_voila = function() {
+        let notebook_path =  Jupyter.notebook.notebook_path;
+        let voila_path = notebook_path.slice(0, notebook_path.length-6);  // without .ipynb
+        let voila_url = Jupyter.notebook.base_url + "voila/render/" + voila_path;
+        window.open(voila_url)
+
+    }
+    var load_ipython_extension = function() {
+        Jupyter.toolbar.add_buttons_group([{
+            id : 'toggle_codecells',
+            label : 'Voila',
+            icon : 'fa-desktop',
+            callback : open_voila
+        }]);
+    };
+    return {
+        load_ipython_extension : load_ipython_extension
+    };
+});


### PR DESCRIPTION
Adds a button to the toolbar of the classical notebook, which makes voila more visible. 
<img width="845" alt="screen shot 2018-12-07 at 11 48 15" src="https://user-images.githubusercontent.com/1765949/49643455-0e3e7980-fa16-11e8-98ec-dfc754c847aa.png">
solved #36