### PR TITLE
WIP: extension to add voila to the command palette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ __pycache__
 \#*#
 .#*
 .coverage
-src
 
 *.swp
 *.map

--- a/packages/jupyterlab-voila/package.json
+++ b/packages/jupyterlab-voila/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "jupyterlab-voila",
+  "version": "0.1.0",
+  "description": "A JupyterLab extension for Voila",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
+  "homepage": "https://github.com/QuantStack/voila",
+  "bugs": {
+    "url": "https://github.com/QuantStack/voila/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Maarten Breddels, Sylvain Corlay",
+  "files": [
+    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/QuantStack/voila.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w",
+    "prepare": "npm run clean && npm run build"
+  },
+  "peerDependencies": {
+    "@jupyterlab/application": "^0.19.0",
+    "@jupyterlab/apputils": "^0.19.0",
+    "@jupyterlab/notebook": "^0.19.0",
+    "@jupyterlab/mainmenu": "^0.19.0",
+    "@jupyterlab/docregistry": "^0.19.0",
+    "@jupyterlab/fileeditor": "^0.19.0"
+  },
+  "devDependencies": {
+    "rimraf": "^2.6.1",
+    "typescript": "~2.9.2",
+    "@jupyterlab/application": "^0.19.0",
+    "@jupyterlab/apputils": "^0.19.0",
+    "@jupyterlab/notebook": "^0.19.0",
+    "@jupyterlab/mainmenu": "^0.19.0",
+    "@jupyterlab/docregistry": "^0.19.0",
+    "@jupyterlab/fileeditor": "^0.19.0"
+  },
+  "jupyterlab": {
+    "extension": true
+  },
+  "dependencies": {
+    "@jupyterlab/application": "^0.19.0",
+    "@jupyterlab/mainmenu": "^0.8.0"
+  }
+}

--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -1,0 +1,88 @@
+import {
+  JupyterLab, JupyterLabPlugin
+} from '@jupyterlab/application';
+
+import {
+  INotebookTracker, NotebookPanel
+} from '@jupyterlab/notebook';
+
+import {
+  ReadonlyJSONObject
+} from '@phosphor/coreutils';
+
+import {
+    ICommandPalette,
+} from '@jupyterlab/apputils';
+
+import {
+  IMainMenu
+} from '@jupyterlab/mainmenu';
+
+import {
+  PageConfig
+} from '@jupyterlab/coreutils';	
+
+import '../style/index.css';
+
+
+/**
+ * Initialization data for the jupyterlab-voila extension.
+ */
+const extension: JupyterLabPlugin<void> = {
+  id: 'jupyterlab-voila',
+  autoStart: true,
+  requires: [INotebookTracker, ICommandPalette, IMainMenu],
+  activate: (app: JupyterLab, notebooks: INotebookTracker, palette: ICommandPalette, menu: IMainMenu | null) => {
+    console.log('JupyterLab extension jupyterlab-voila is activated!!!!!!!!');
+
+    function getCurrent(args: ReadonlyJSONObject): NotebookPanel | null {
+        const widget = notebooks.currentWidget;
+        const activate = args['activate'] !== false;
+
+        if (activate && widget) {
+          app.shell.activateById(widget.id);
+        }
+
+        return widget;
+    }
+
+    function isEnabled(): boolean {
+        return (
+          notebooks.currentWidget !== null &&
+          notebooks.currentWidget === app.shell.currentWidget
+        );
+    }
+
+    app.commands.addCommand(CommandIDs.voilaRender, {
+        label: 'Open/Render Notebook with Voila',
+        execute: async (args) => {
+          const current = getCurrent(args);
+
+          if (current) {
+            const notebookPath = current.context.path;
+            const voilaPath = notebookPath.slice(0, notebookPath.length-6);  // without .ipynb
+            const baseUrl = PageConfig.getBaseUrl();
+            const voilaUrl = baseUrl + "voila/render/" + voilaPath;
+            window.open(voilaUrl)
+          }
+        },
+        isEnabled
+    });
+    palette.addItem({command:CommandIDs.voilaRender, category:'Notebook Operations'})
+
+
+    // TODO: what would be a good place to add it to the menu?
+    // menu.fileMenu.addGroup(
+    //     [
+    //       { command: CommandIDs.voilaRender },
+    //     ],
+    //     1000
+    // );
+    
+  }
+};
+
+export default extension;
+export namespace CommandIDs{
+    export const voilaRender = 'notebook:render-with-voila'
+}

--- a/packages/jupyterlab-voila/tsconfig.json
+++ b/packages/jupyterlab-voila/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "lib": ["es2015", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noUnusedLocals": true,
+    "outDir": "./lib",
+    "target": "es2015",
+    "strict": true,
+    "strictNullChecks": false,
+    "types": [],
+    "skipLibCheck": true
+  },
+  "include": ["src/*"]
+}


### PR DESCRIPTION
Gives an option to open the current notebook with the command palette:
<img width="730" alt="screen shot 2018-12-07 at 13 46 28" src="https://user-images.githubusercontent.com/1765949/49648597-a8a6b900-fa26-11e8-970e-74ad9591561e.png">

 * Do we want 1 voila jlab extension? If yes, I could move it from `packages/jupyterlab-voila` to just `jupyterlab-voila`
 * Do we want to add it to the menu? If so, what would be a good place? View?
 * Do we want it to come with a preset shortcut key (e.g. cmd-something-v)?