### PR TITLE
Use classical notebook extension mechanism for enabling e.g. widgets

### DIFF
--- a/share/jupyter/voila/template/default/nbconvert_templates/base.tpl
+++ b/share/jupyter/voila/template/default/nbconvert_templates/base.tpl
@@ -35,13 +35,21 @@
 {% block footer %}
 {% block footer_js %}
 <script
-    data-main="{{resources.base_url}}voila/static/main"
-    data-jupyter-kernel-id="{{resources.kernel_id}}"
     src="{{resources.base_url}}voila/static/require.min.js"
     integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
     crossorigin="anonymous">
 </script>
-<script>requirejs.config({ baseUrl: '{{resources.base_url}}voila/static' })</script>
+<script>
+requirejs.config({ baseUrl: '{{resources.base_url}}voila/' })
+requirejs(
+    [
+        "static/main",
+    {% for ext in resources.nbextensions -%}
+        "{{resources.base_url}}voila/nbextensions/{{ ext }}.js",
+    {% endfor %}
+    ]
+)
+</script>
 
 {% endblock footer_js %}
 {{ super() }}

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -30,6 +30,14 @@ class VoilaHandler(JupyterHandler):
         # if the handler got a notebook_path argument, always serve that
         notebook_path = self.notebook_path or path
 
+        # generate a list of nbextensions that are enabled for the classical notebook
+        # a template can use that to load classical notebook extensions, but does not have to
+        notebook_config = self.config_manager.get('notebook')
+        # except for the widget extension itself, since voila has its own
+        if "jupyter-js-widgets/extension" in notebook_config['load_extensions']:
+            notebook_config['load_extensions']["jupyter-js-widgets/extension"] = False
+        nbextensions = [name for name, enabled in notebook_config['load_extensions'].items() if enabled]
+
         model = self.contents_manager.get(path=notebook_path)
         if 'content' in model:
             notebook = model['content']
@@ -47,7 +55,8 @@ class VoilaHandler(JupyterHandler):
         # render notebook to html
         resources = {
             'kernel_id': kernel_id,
-            'base_url': self.base_url
+            'base_url': self.base_url,
+            'nbextensions': nbextensions
         }
 
         exporter = HTMLExporter(

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -14,6 +14,7 @@ from jinja2 import Environment, FileSystemLoader
 
 from jupyter_server.utils import url_path_join
 from jupyter_server.base.handlers import path_regex
+from jupyter_server.base.handlers import FileFindHandler
 
 from .paths import ROOT, TEMPLATE_ROOT, STATIC_ROOT
 from .handler import VoilaHandler
@@ -37,5 +38,14 @@ def load_jupyter_server_extension(server_app):
         }),
         (url_path_join(base_url, '/voila'), VoilaTreeHandler),
         (url_path_join(base_url, '/voila/tree' + path_regex), VoilaTreeHandler),
-        (url_path_join(base_url, '/voila/static/(.*)'),  tornado.web.StaticFileHandler, {'path': STATIC_ROOT})
+        (url_path_join(base_url, '/voila/static/(.*)'),  tornado.web.StaticFileHandler, {'path': STATIC_ROOT}),
+        # this handler serves the nbextensions similar to the classical notebook
+        (
+            url_path_join(base_url, r'/voila/nbextensions/(.*)'),
+            FileFindHandler,
+            {
+                'path': web_app.settings['nbextensions_path'],
+                'no_cache_paths': ['/'],  # don't cache anything in nbextensions
+            },
+        )
     ])

--- a/voila/static/main.js
+++ b/voila/static/main.js
@@ -6,7 +6,7 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-require(['libwidgets'], function(lib) {
+require(['static/libwidgets'], function(lib) {
     var widgetApp = new lib.WidgetApplication(lib.requireLoader);
 
     window.addEventListener('beforeunload', function (e) {


### PR DESCRIPTION
If classical notebook extensions are installed/enabled, voila now picks those up and serves them (with the exception of jupyter-js-widgets).
This does not avoid other templates from using a different system, and with #48 we could show how to do this, e.g.
 * using a CDN
 * using this new approach of using the classical notebook system
 * a jupyter lab single bundle approach.

