### PR TITLE
Fixes for templates, add support for tornado settings

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -20,7 +20,7 @@ import tornado.ioloop
 import tornado.web
 
 from traitlets.config.application import Application
-from traitlets import Unicode, Integer, Bool, List, default
+from traitlets import Unicode, Integer, Bool, Dict, List, default
 
 from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
 from jupyter_server.services.kernels.handlers import KernelHandler, ZMQChannelsHandler
@@ -135,6 +135,15 @@ class Voila(Application):
     )
 
     config_file_paths = List(Unicode(), config=True, help='Paths to search for voila.(py|json)')
+
+    tornado_settings = Dict(
+        {},
+        config=True,
+        help=(
+            'Extra settings to apply to tornado application, e.g. headers, ssl, etc'
+        )
+    )
+
     @default('config_file_paths')
     def _config_file_paths_default(self):
         return [os.getcwd()] + jupyter_config_path()
@@ -243,6 +252,7 @@ class Voila(Application):
         )
 
         base_url = self.app.settings.get('base_url', '/')
+        self.app.settings.update(self.tornado_settings)
 
         handlers = []
 
@@ -279,6 +289,7 @@ class Voila(Application):
                     'notebook_path': os.path.relpath(self.notebook_path, self.root_dir),
                     'strip_sources': self.strip_sources,
                     'nbconvert_template_paths': self.nbconvert_template_paths,
+                    'template_name': self.template,
                     'config': self.config
                 }
             ))

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -21,6 +21,7 @@ class VoilaHandler(JupyterHandler):
         self.notebook_path = kwargs.pop('notebook_path', [])    # should it be []
         self.strip_sources = kwargs.pop('strip_sources', True)
         self.nbconvert_template_paths = kwargs.pop('nbconvert_template_paths', [])
+        self.template_name = kwargs.pop('template_name', 'default')
         self.exporter_config = kwargs.pop('config', None)
 
     @tornado.web.authenticated


### PR DESCRIPTION
- Fix for hardcoded `default` template
~~- Adding in CSP endpoint~~ moved to #89 
~~- Exposing tornado settings, coupled with CSP endpoint allows you to put voila behind iframe~~

~~As an example, embed voila in an iframe and set~~

```python
v = Voila()
v.tornado_settings = {'headers': {'Content-Security-Policy': "frame-ancestors 'self' localhost:*"}}
```
