### PR TITLE
Tornado6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
   - conda update -q conda
   - conda info -a
   - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server pytest==3.10.1 pytest-cov nodejs flake8
-  - pip install git+https://github.com/maartenbreddels/jupyter_server.git@fix_tornado6
   - source activate test-environment
+  - pip install git+https://github.com/maartenbreddels/jupyter_server.git@fix_tornado6
 install:
   - pip install ".[test]"
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - conda info -a
   - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server pytest==3.10.1 pytest-cov nodejs flake8
   - source activate test-environment
-  - pip install --force git+https://github.com/maartenbreddels/jupyter_server.git@fix_tornado6
+  - pip install --upgrade --no-deps --force-reinstall git+https://github.com/maartenbreddels/jupyter_server.git@fix_tornado6
 install:
   - pip install ".[test]"
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - conda info -a
   - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server pytest==3.10.1 pytest-cov nodejs flake8
   - source activate test-environment
-  - pip install git+https://github.com/maartenbreddels/jupyter_server.git@fix_tornado6
+  - pip install --force git+https://github.com/maartenbreddels/jupyter_server.git@fix_tornado6
 install:
   - pip install ".[test]"
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
   - conda update -q conda
   - conda info -a
   - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server pytest==3.10.1 pytest-cov nodejs flake8
+  - pip install git+https://github.com/maartenbreddels/jupyter_server.git@fix_tornado6
   - source activate test-environment
 install:
   - pip install ".[test]"

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ setup_args = {
     },
     'install_requires': [
         'jupyter_server>=0.0.3',
-        'nbconvert>=5.4,<6'
+        'nbconvert>=5.4.1,<6'
     ],
     'extras_require': {
         'test': ['mock', 'pytest<4', 'pytest-tornado5']


### PR DESCRIPTION
If we want to support tornado 6, we should depend on nbconvert 5.4.1 (https://github.com/jupyter/nbconvert/issues/894)

Also using this PR to test if https://github.com/jupyter/jupyter_server/pull/43 solves our issues