### PR TITLE
Blacklisting nbextensions and workaround for QGrid

### DIFF
--- a/share/jupyter/voila/template/default/nbconvert_templates/base.tpl
+++ b/share/jupyter/voila/template/default/nbconvert_templates/base.tpl
@@ -39,8 +39,15 @@
     integrity="sha256-Ae2Vz/4ePdIu6ZyI/5ZGsYnb+m0JlOmKPjt6XZ9JJkA="
     crossorigin="anonymous">
 </script>
+
 <script>
 requirejs.config({ baseUrl: '{{resources.base_url}}voila/', waitSeconds: 30})
+
+// TODO: This will make qgrid work and possibly other widget nbextensions
+// until we set up proper packaging, or fix qgrid
+//   see https://github.com/QuantStack/voila/issues/72
+define("base/js/dialog", [], () => {})
+
 requirejs(
     [
         "static/main",

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -43,13 +43,20 @@ class VoilaHandler(JupyterHandler):
         # generate a list of nbextensions that are enabled for the classical notebook
         # a template can use that to load classical notebook extensions, but does not have to
         notebook_config = self.config_manager.get('notebook')
-        # except for the widget extension itself, since voila has its own
         load_extensions = notebook_config.get('load_extensions', {})
-        if "jupyter-js-widgets/extension" in load_extensions:
-            load_extensions["jupyter-js-widgets/extension"] = False
-            nbextensions = [name for name, enabled in load_extensions.items() if enabled]
-        else:
-            nbextensions = []
+        # except for the widget extension itself, since voila has its own
+        # and some others that would only work in the notebook
+        blacklist = [
+            'voila/nbextension',
+            'jupyter-js-widgets/extension',
+            'beakerx/extension',
+            'nbdime/index',
+        ]
+        for extension in blacklist:
+            if extension in load_extensions:
+                load_extensions[extension] = False
+        nbextensions = [name for name, enabled in load_extensions.items() if enabled]
+
 
         model = self.contents_manager.get(path=notebook_path)
         if 'content' in model:

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -57,7 +57,6 @@ class VoilaHandler(JupyterHandler):
                 load_extensions[extension] = False
         nbextensions = [name for name, enabled in load_extensions.items() if enabled]
 
-
         model = self.contents_manager.get(path=notebook_path)
         if 'content' in model:
             notebook = model['content']


### PR DESCRIPTION
Since we load extensions that are expecting a notebook environment (and cannot distinguish between widgets extensions or other extensions) some will try to load modules and give ugly errors.
![image](https://user-images.githubusercontent.com/1765949/53955039-2d61ab80-40d8-11e9-90eb-15bd4a521e86.png)

Apart from the `jupyter-js-widgets/extension` there are some other extensions that make no sense at all, I've blacklisted them.

Some extensions may actually work, like QGrid as long as a module is defined. (see also https://github.com/QuantStack/voila/issues/72 )