### PR TITLE
Configure voila using traitlets configuration system

### DIFF
--- a/tests/app/config_paths_test.py
+++ b/tests/app/config_paths_test.py
@@ -1,0 +1,33 @@
+# test all objects that should be configurable
+import pytest
+import json
+import os
+
+
+BASE_DIR = os.path.dirname(__file__)
+
+
+@pytest.fixture
+def voila_config_file_paths_arg():
+    path = os.path.join(BASE_DIR, '..', 'configs', 'general')
+    return '--VoilaTest.config_file_paths=[%r]' % path
+
+
+def test_config_app(voila_app):
+    assert voila_app.template == 'gridstack'
+
+
+def test_config_kernel_manager(voila_app):
+    assert voila_app.kernel_manager.cull_interval == 10
+
+
+def test_config_contents_manager(voila_app):
+    assert voila_app.contents_manager.use_atomic_writing == False
+
+
+@pytest.mark.gen_test
+def test_template_gridstack(http_client, base_url):
+    response = yield http_client.fetch(base_url)
+    assert response.code == 200
+    assert 'gridstack.css' in response.body.decode('utf-8')
+    assert 'Hi Voila' in response.body.decode('utf-8')

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -23,9 +23,15 @@ def voila_args_extra():
 
 
 @pytest.fixture
-def voila_args(voila_notebook, voila_args_extra):
+def voila_config_file_paths_arg():
+    # we don't want the tests to use any configuration on the system
+    return '--VoilaTest.config_file_paths=[]'
+
+
+@pytest.fixture
+def voila_args(voila_notebook, voila_args_extra, voila_config_file_paths_arg):
     debug_args = ['--VoilaTest.log_level=DEBUG'] if os.environ.get('VOILA_TEST_DEBUG', False) else []
-    return [voila_notebook] + voila_args_extra + debug_args
+    return [voila_notebook, voila_config_file_paths_arg] + voila_args_extra + debug_args
 
 
 @pytest.fixture

--- a/tests/app/execute_test.py
+++ b/tests/app/execute_test.py
@@ -15,7 +15,9 @@ except:
 def test_hello_world(http_client, base_url):
     response = yield http_client.fetch(base_url)
     assert response.code == 200
-    assert 'Hi Voila' in response.body.decode('utf-8')
+    html_text = response.body.decode('utf-8')
+    assert 'Hi Voila' in html_text
+    assert 'gridstack.css' not in html_text, "gridstack should not be the default"
 
 
 @pytest.mark.gen_test

--- a/tests/configs/general/voila.json
+++ b/tests/configs/general/voila.json
@@ -1,0 +1,11 @@
+{
+    "Voila": {
+        "template": "gridstack"
+    },
+    "MappingKernelManager": {
+        "cull_interval": 10
+    },
+    "LargeFileManager": {
+        "use_atomic_writing": false
+    }
+}

--- a/voila/app.py
+++ b/voila/app.py
@@ -201,7 +201,6 @@ class Voila(Application):
         self.ioloop.add_callback_from_signal(self.ioloop.stop)
 
     def start(self):
-        self.setup_template_dirs()
         self.connection_dir = tempfile.mkdtemp(
             prefix='voila_',
             dir=self.connection_dir_root


### PR DESCRIPTION
Needs rebasing after #83 is merged.
Will replace #80, by doing, e.g:

# Example usage
~/.jupyter/voila.py
```
c.MappingKernelManager.cull_interval = 10
```
or, ${prefix}/etc/jupyter/voila.json
```
{
    "Voila": {
        "template": "gridstack"
    },
    "MappingKernelManager": {
        "cull_interval": 10
    }
}
```

Running voila with `--Voila.log_level=DEBUG` will show which paths it will scan.
```
[Voila] Looking for voila in /etc/jupyter
[Voila] Looking for voila in /usr/local/etc/jupyter
[Voila] Looking for voila in /Users/maartenbreddels/miniconda3/envs/voila/etc/jupyter
[Voila] Loaded config file: /Users/maartenbreddels/miniconda3/envs/voila/etc/jupyter/voila.json
[Voila] Looking for voila in /Users/maartenbreddels/.jupyter
```

# TODO
 * [x] rebase on master after #83 is merged
 * [x] write tests
 * [x] make tests ignore config options