### PR TITLE
Implement Output widget at nbconvert level for interact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_install:
   - conda info -a
   - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server pytest==3.10.1 pytest-cov nodejs flake8
   - source activate test-environment
+  # we need this branch to perform testing
+  - pip install --upgrade --no-deps --force-reinstall git+https://github.com/maartenbreddels/nbconvert.git@widget_state#egg=nbconvert
 install:
   - pip install ".[test]"
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,10 @@ before_install:
   - conda info -a
   - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server pytest==3.10.1 pytest-cov nodejs flake8 ipywidgets
   - source activate test-environment
-  # we need this branch to perform testing
-  - pip install --upgrade --no-deps --force-reinstall git+https://github.com/maartenbreddels/nbconvert.git@widget_state#egg=nbconvert
 install:
   - pip install ".[test]"
+  # we need this branch to perform testing, do it after the pip install above, otherwise we 'downgrade'
+  - pip install --upgrade --no-deps --force-reinstall git+https://github.com/maartenbreddels/nbconvert.git@widget_state#egg=nbconvert
 before_script:
   - flake8 voila
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server pytest==3.10.1 pytest-cov nodejs flake8
+  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server pytest==3.10.1 pytest-cov nodejs flake8 ipywidgets
   - source activate test-environment
   # we need this branch to perform testing
   - pip install --upgrade --no-deps --force-reinstall git+https://github.com/maartenbreddels/nbconvert.git@widget_state#egg=nbconvert

--- a/tests/execute_output_test.py
+++ b/tests/execute_output_test.py
@@ -1,0 +1,51 @@
+import os
+
+from voila.execute import executenb
+from nbformat import read, NO_CONVERT
+from copy import deepcopy
+
+
+BASE_DIR = os.path.dirname(__file__)
+WIDGET_MIME_TYPE_VIEW = 'application/vnd.jupyter.widget-view+json'
+WIDGET_MIME_TYPE_STATE = 'application/vnd.jupyter.widget-state+json'
+
+
+# based on nbconvert.preprocessors.tests.test_execute.TestExecute
+# we cannot import it because pytest would then also execute thoses tests
+def normalize_output(output):
+    """
+    Normalizes outputs for comparison.
+    """
+    output = dict(output)
+    if 'metadata' in output:
+        del output['metadata']
+    if 'application/vnd.jupyter.widget-view+json' in output.get('data', {}):
+        output['data']['application/vnd.jupyter.widget-view+json']['model_id'] = '<MODEL_ID>'
+
+
+def normalize_outputs(outputs):
+    for output in outputs:
+        normalize_output(output)
+
+
+
+def test_execute_output():
+    path = os.path.join(BASE_DIR, "notebooks/output.ipynb")
+    nb = read(path, NO_CONVERT)
+    nb_voila = deepcopy(nb)
+    executenb(nb_voila)
+
+    widget_states = nb.metadata.widgets[WIDGET_MIME_TYPE_STATE]['state']
+    widget_states_voila = nb_voila.metadata.widgets[WIDGET_MIME_TYPE_STATE]['state']
+
+    for cell_voila, cell in zip(nb_voila.cells, nb.cells):
+        for output_voila, output in zip(cell_voila.outputs, cell.outputs):
+            if 'data' in output and WIDGET_MIME_TYPE_VIEW in output['data']:
+                widget_id = output['data'][WIDGET_MIME_TYPE_VIEW]['model_id']
+                widget_id_voila = output_voila['data'][WIDGET_MIME_TYPE_VIEW]['model_id']
+                widget_state = widget_states[widget_id]
+                widget_state_voila = widget_states_voila[widget_id_voila]
+                assert widget_state.state.get('outputs', []) == widget_state_voila.state.get('outputs', [])
+            normalize_output(output_voila)
+            normalize_output(output)
+            assert output_voila == output

--- a/tests/notebooks/output.ipynb
+++ b/tests/notebooks/output.ipynb
@@ -1,0 +1,356 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4d6af5172a774f7ebfdfaf36cce893c5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from IPython.display import clear_output\n",
+    "output1 = widgets.Output()\n",
+    "output1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hi\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"hi\")\n",
+    "with output1:\n",
+    "    print(\"in output\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1993ee53d793450a9a4d830c700496b5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "output2 = widgets.Output()\n",
+    "output2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hi2\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"hi2\")\n",
+    "with output2:\n",
+    "    print(\"in output2\")\n",
+    "    clear_output(wait=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "22a925976945430b8ddbb0b9b754734b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "output3 = widgets.Output()\n",
+    "output3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hi3\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"hi3\")\n",
+    "with output3:\n",
+    "    print(\"hello\")\n",
+    "    clear_output(wait=True)\n",
+    "    print(\"world\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3a32b286c0464dbeb3819213a3bf6133",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "output4 = widgets.Output()\n",
+    "output4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hi4\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"hi4\")\n",
+    "with output4:\n",
+    "    print(\"hello world\")\n",
+    "    clear_output()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9faaadcde2e94306b7187ffc1587cd24",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "output5 = widgets.Output()\n",
+    "output5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"hi5\")\n",
+    "with output5:\n",
+    "    display(\"hello world\") # this is not a stream but plain text\n",
+    "clear_output()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "0c97c6f319e6494e918df877e90f1ede": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.1.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1993ee53d793450a9a4d830c700496b5": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_5584875f1aa94595852160dada91122a",
+       "outputs": [
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "in output2\n"
+        }
+       ]
+      }
+     },
+     "22a925976945430b8ddbb0b9b754734b": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_a3204e1e6a6649c2802861b9f389314e",
+       "outputs": [
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "world\n"
+        }
+       ]
+      }
+     },
+     "3a32b286c0464dbeb3819213a3bf6133": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_561942f986f34d4ca3f7bdbe717e9289"
+      }
+     },
+     "4d6af5172a774f7ebfdfaf36cce893c5": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_9357eb7d15c64c7d9e007a2b5ab9cef0",
+       "outputs": [
+        {
+         "name": "stdout",
+         "output_type": "stream",
+         "text": "in output\n"
+        }
+       ]
+      }
+     },
+     "5584875f1aa94595852160dada91122a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.1.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "561942f986f34d4ca3f7bdbe717e9289": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.1.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9357eb7d15c64c7d9e007a2b5ab9cef0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.1.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9faaadcde2e94306b7187ffc1587cd24": {
+      "model_module": "@jupyter-widgets/output",
+      "model_module_version": "1.0.0",
+      "model_name": "OutputModel",
+      "state": {
+       "layout": "IPY_MODEL_0c97c6f319e6494e918df877e90f1ede",
+       "outputs": [
+        {
+         "data": {
+          "text/plain": "'hello world'"
+         },
+         "metadata": {},
+         "output_type": "display_data"
+        }
+       ]
+      }
+     },
+     "a3204e1e6a6649c2802861b9f389314e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.1.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/notebooks/output.ipynb
+++ b/tests/notebooks/output.ipynb
@@ -226,9 +226,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "language": "python"
   },
   "language_info": {
    "codemirror_mode": {

--- a/voila/execute.py
+++ b/voila/execute.py
@@ -1,0 +1,99 @@
+from nbconvert.preprocessors.execute import ExecutePreprocessor
+from ipykernel.jsonutil import json_clean
+
+class OutputWidget:
+    """This class mimics a front end output widget"""
+    def __init__(self, comm_id, state, kernel_client, executor):
+        self.comm_id = comm_id
+        self.state = state
+        self.kernel_client = kernel_client
+        self.executor = executor
+        self.topic = ('comm-%s' % self.comm_id).encode('ascii')
+        self.outputs = self.state['outputs']
+
+    def clear_output(self, outs, msg, cell_index):
+        self.parent_header = msg['parent_header']
+        self.outputs = []
+
+    def sync_state(self):
+        state = {'outputs': self.outputs}
+        msg = {'method': 'update', 'state': state, 'buffer_paths': []}
+        self.send(msg)
+
+    def _publish_msg(self, msg_type, data=None, metadata=None, buffers=None, **keys):
+        """Helper for sending a comm message on IOPub"""
+        data = {} if data is None else data
+        metadata = {} if metadata is None else metadata
+        content = json_clean(dict(data=data, comm_id=self.comm_id, **keys))
+        msg = self.kernel_client.session.msg(msg_type, content=content, parent=self.parent_header, metadata=metadata)
+        self.kernel_client.shell_channel.send(msg)
+
+    def send(self, data=None, metadata=None, buffers=None):
+        self._publish_msg('comm_msg', data=data, metadata=metadata, buffers=buffers)
+
+    def output(self, outs, msg, display_id, cell_index):
+        self.parent_header = msg['parent_header']
+        content = msg['content']
+        if 'data' not in content:
+            output = {"output_type": "stream", "text": content['text'], "name": content['name']}
+        else:
+            data = content['data']
+            output = {"output_type": "display_data", "data": data, "metadata": {}}
+        self.outputs.append(output)
+        self.sync_state()
+
+    def set_state(self, state):
+        if 'msg_id' in state:
+            msg_id = state.get('msg_id')
+            if msg_id:
+                self.executor.output_hook[msg_id] = self
+                self.msg_id = msg_id
+            else:
+                del self.executor.output_hook[self.msg_id]
+                self.msg_id = msg_id
+
+class ExecutePreprocessorWithOutputWidget(ExecutePreprocessor):
+    """Execute, but respect the output widget behaviour"""
+    def preprocess(self, nb, resources, km=None):
+        self.output_hook = {}
+        self.output_objects = {}
+        return super(ExecutePreprocessorWithOutputWidget, self).preprocess(nb, resources=resources, km=km)
+
+    def output(self, outs, msg, display_id, cell_index):
+        parent_msg_id = msg['parent_header'].get('msg_id')
+        if parent_msg_id in self.output_hook:
+            self.output_hook[parent_msg_id].output(outs, msg, display_id, cell_index)
+            return
+        super(ExecutePreprocessorWithOutputWidget, self).output(outs, msg, display_id, cell_index)
+
+    def handle_comm_msg(self, msg):
+        self.log.debug('comm msg: %r', msg)
+        if msg['msg_type'] == 'comm_open':
+            content = msg['content']
+            data = content['data']
+            state = data['state']
+            comm_id = msg['content']['comm_id']
+            if state['_model_module'] == '@jupyter-widgets/output' and state['_model_name'] == 'OutputModel':
+                self.output_objects[comm_id] = OutputWidget(comm_id, state, self.kc, self)
+        elif msg['msg_type'] == 'comm_msg':
+            content = msg['content']
+            data = content['data']
+            state = data['state']
+            comm_id = msg['content']['comm_id']
+            if comm_id in self.output_objects:
+                self.output_objects[comm_id].set_state(state)
+
+    def clear_output(self, outs, msg, cell_index):
+        parent_msg_id = msg['parent_header'].get('msg_id')
+        if parent_msg_id in self.output_hook:
+            self.output_hook[parent_msg_id].clear_output(outs, msg, cell_index)
+            return
+        super(ExecutePreprocessorWithOutputWidget, self).clear_output(outs, msg, cell_index)
+
+
+def executenb(nb, cwd=None, km=None, **kwargs):
+    resources = {}
+    if cwd is not None:
+        resources['metadata'] = {'path': cwd}
+    ep = ExecutePreprocessorWithOutputWidget(**kwargs)
+    return ep.preprocess(nb, resources, km=km)[0]

--- a/voila/execute.py
+++ b/voila/execute.py
@@ -66,7 +66,7 @@ class ExecutePreprocessorWithOutputWidget(ExecutePreprocessor):
             return
         super(ExecutePreprocessorWithOutputWidget, self).output(outs, msg, display_id, cell_index)
 
-    def handle_comm_msg(self, msg):
+    def handle_comm_msg(self, outs, msg, cell_index):
         self.log.debug('comm msg: %r', msg)
         if msg['msg_type'] == 'comm_open':
             content = msg['content']

--- a/voila/execute.py
+++ b/voila/execute.py
@@ -95,10 +95,11 @@ class ExecutePreprocessorWithOutputWidget(ExecutePreprocessor):
         elif msg['msg_type'] == 'comm_msg':
             content = msg['content']
             data = content['data']
-            state = data['state']
-            comm_id = msg['content']['comm_id']
-            if comm_id in self.output_objects:
-                self.output_objects[comm_id].set_state(state)
+            if 'state' in data:
+                state = data['state']
+                comm_id = msg['content']['comm_id']
+                if comm_id in self.output_objects:
+                    self.output_objects[comm_id].set_state(state)
 
     def clear_output(self, outs, msg, cell_index):
         parent_msg_id = msg['parent_header'].get('msg_id')

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -11,7 +11,7 @@ import tornado.web
 from jupyter_server.base.handlers import JupyterHandler
 
 import nbformat  # noqa: F401
-from nbconvert.preprocessors.execute import executenb
+from .execute import executenb
 from nbconvert import HTMLExporter
 
 


### PR DESCRIPTION
As mentioned in #19 and #85 there are some issues with interact. Interact(ion) uses the Output widget a lot, which relies on the frontend to handle display and clear_output differently. 

A part of the fix is in https://github.com/jupyter/nbconvert/pull/969 which deals with `wait=True`, but this only solves part of the issue.

When nbconvert is used to execute the notebook, there is no OutputWidget that can hook into the display mechanism to redirect display and clear_output calls. This custom executor creates a 'fake' Output widget that mirrors this behaviour.

This is to show that it is possible to support interact with voila, I am not sure this is the best solution. Other solution are:
 1. Implement display/clear_output redirects kernel side, in Python this is simply monkey patching display and clear_output and possibly stdout/stderr, but I am not sure this will work with with xeus-python, and similar solutions would be needed for all the other kernels.
 2. Do no use nbconvert for the execution, only start executing once a frontend is connected.

I think the core problem is that interact(ion) relies on the Output widget being connected to the frontend. We could solve some problems by actually modifying `Output.ouputs` at the kernel side, and never invoke display/clear_output, but directly invoke methods on the Output widget.

If we want to go forward with this approach (which would be the most compatible one), this requires a few more tweaks and a few tests (wait=True for the output widget it no supported)