### PR TITLE
Fix undefined manager

### DIFF
--- a/js/src/manager.js
+++ b/js/src/manager.js
@@ -28,8 +28,15 @@ export class WidgetManager extends JupyterLabManager {
 
     constructor(kernel) {
         const context = createContext(kernel);
-        const rendermime = createRenderMimeRegistry();
+        const rendermime = new RenderMimeRegistry({
+            initialFactories: standardRendererFactories
+        });
         super(context, rendermime);
+        rendermime.addFactory({
+            safe: false,
+            mimeTypes: [WIDGET_MIMETYPE],
+            createRenderer: options => new WidgetRenderer(options, this)
+        }, 1);
         this._registerWidgets();
         this.loader = requireLoader;
     }
@@ -155,14 +162,3 @@ function createContext(kernel) {
     };
 }
 
-function createRenderMimeRegistry() {
-    const rendermime = new RenderMimeRegistry({
-        initialFactories: standardRendererFactories
-    });
-    rendermime.addFactory({
-        safe: false,
-        mimeTypes: [WIDGET_MIMETYPE],
-        createRenderer: options => new WidgetRenderer(options, manager)
-    }, 1);
-    return rendermime;
-}


### PR DESCRIPTION
`WidgetManager` takes a manager as a second argument which was not defined in this case, resulting in a: `ReferenceError: manager is not defined`

Tested with:

```python
from ipywidgets import IntSlider, Label, Output

out = Output()
slider = IntSlider(min=0, max=100)
label = Label(value='Test')

@out.capture()
def on_change(change):
    display(label)

slider.observe(on_change, names='value')

with out:
    display(slider)    
out
```

Although this change seems to fix the `manager is not defined` error, the code posted above still doesn't work as expected (need more investigation).