### PR TITLE
Add data-base-url to the default template body

### DIFF
--- a/share/jupyter/voila/template/default/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/template/default/nbconvert_templates/voila.tpl
@@ -53,7 +53,7 @@ div#notebook-container{
 {%- endblock html_head_css -%}
 
 {% block body %}
-<body>
+<body data-base-url="{{resources.base_url}}voila/">
   <div tabindex="-1" id="notebook" class="border-box-sizing">
     <div class="container" id="notebook-container">
 {{ super() }}


### PR DESCRIPTION
Many classic notebook extensions use the `data-base-url`attribute from the body to load static assets.

[For example with `ipyleaflet`](https://github.com/jupyter-widgets/ipyleaflet/blob/afa4d6ea290661fc4e78ef5683293e5e8053be6f/js/src/notebook.js#L2):

```javascript
__webpack_public_path__ = document.querySelector('body').getAttribute('data-base-url') + 'nbextensions/jupyter-leaflet/';
```

This change adds the `data-base-url` attribute to the body of the default template, so the attribute can correctly be resolved.

### Example with `ipyleaflet`

Using the example from https://ipyleaflet.readthedocs.io/en/latest/api_reference/marker.html

#### Before

![image](https://user-images.githubusercontent.com/591645/56053393-42270400-5d54-11e9-8f54-97389b11bdd6.png)


The marker is not loaded. Dev tools log:

```
GET http://localhost:8866/voila/render/notebooks/nullnbextensions/jupyter-leaflet/2273e3d8ad9264b7daa5bdbf8e6b47f8.png 404 (Not Found)
```

#### After

![image](https://user-images.githubusercontent.com/591645/56053412-4fdc8980-5d54-11e9-9531-9be3d7742ee5.png)
