### PR TITLE
Reverse proxy

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -358,6 +358,7 @@ class Voila(Application):
         self.config_manager = ConfigManager(parent=self, read_config_path=read_config_path)
 
         self.app = tornado.web.Application(
+            base_url=self.base_url,
             kernel_manager=self.kernel_manager,
             allow_remote_access=True,
             autoreload=self.autoreload,


### PR DESCRIPTION
Here's the use case:

I want to host multiple voila apps and dynamically spawn them. Rather than using my current strategy of launching against a unique port bound to 0.0.0.0 and using an iframe, i want to reverse proxy through my main app. The app will serve notebooks on `/voila/<notebook name>` and proxy through to voila instances running against local host.

Using this code, the server will set `server_url` to `/`, so that the server side hosts routes in the usual way, but `base_url` will be set to `/voila/<notebook name>` so client requests get proxied to the right voila instance.

Previously these were coupled, meaning if you set base_url to that path, the client requests would go there, but the server would also serve at that path (meaning the actual path it expected would be `/voila/notebook/voila/notebook`)