### PR TITLE
Better connection string log

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -311,7 +311,11 @@ class Voila(Application):
 
     def listen(self):
         self.app.listen(self.port)
-        self.log.info('Voila listening on port %s.' % self.port)
+        if self.tornado_settings.get('ssl_options'):
+            host = 'https://0.0.0.0:%s' % self.port
+        else:
+            host = 'http://0.0.0.0:%s' % self.port
+        self.log.info('Voila listening on %s' % host)
 
         self.ioloop = tornado.ioloop.IOLoop.current()
         try:


### PR DESCRIPTION
Depending on whether `tornado_settings` is setup for SSL will print
<img width="250" alt="Screen Shot 2019-04-17 at 1 39 37 PM" src="https://user-images.githubusercontent.com/3105306/56308855-48333100-6116-11e9-8314-2039cb40f7d6.png">
or
<img width="253" alt="Screen Shot 2019-04-17 at 1 39 42 PM" src="https://user-images.githubusercontent.com/3105306/56308859-49645e00-6116-11e9-9a47-4fd7d0d7e3b5.png">
