### PR TITLE
Fix: set cwd of kernel and pass to nbconvert

### DIFF
--- a/tests/app/cwd_subdir_test.py
+++ b/tests/app/cwd_subdir_test.py
@@ -1,0 +1,18 @@
+# test serving a notebook
+import pytest
+
+@pytest.fixture
+def cwd_subdit_notebook_url(base_url):
+    return base_url +  "/voila/render/subdir/cwd_subdir"
+
+@pytest.fixture
+def voila_args(notebook_directory, voila_args_extra):
+    return ['--VoilaTest.root_dir=%r' % notebook_directory, '--VoilaTest.log_level=DEBUG'] + voila_args_extra
+
+
+@pytest.mark.gen_test
+def test_hello_world(http_client, cwd_subdit_notebook_url):
+    response = yield http_client.fetch(cwd_subdit_notebook_url)
+    html_text = response.body.decode('utf-8')
+    assert 'check for the cwd' in html_text
+

--- a/tests/app/cwd_test.py
+++ b/tests/app/cwd_test.py
@@ -1,0 +1,16 @@
+# tests the --template argument of voila
+import pytest
+import base64
+import os
+
+@pytest.fixture
+def voila_notebook(notebook_directory):
+    return os.path.join(notebook_directory, 'cwd.ipynb')
+
+
+@pytest.mark.gen_test
+def test_template_cwd(http_client, base_url, notebook_directory):
+    response = yield http_client.fetch(base_url)
+    html_text = response.body.decode('utf-8')
+    assert 'check for the cwd' in html_text
+

--- a/tests/notebooks/cwd.ipynb
+++ b/tests/notebooks/cwd.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('./file.txt') as f:\n",
+    "    print(f.read())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/notebooks/file.txt
+++ b/tests/notebooks/file.txt
@@ -1,0 +1,1 @@
+check for the cwd

--- a/tests/notebooks/subdir/cwd_subdir.ipynb
+++ b/tests/notebooks/subdir/cwd_subdir.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('..//file.txt') as f:\n",
+    "    print(f.read())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/server/cwd_subdir_test.py
+++ b/tests/server/cwd_subdir_test.py
@@ -1,0 +1,19 @@
+# NOTE: this is a duplicate of ../app/cwd_subdir_test.py
+# we might want to find a better pattern of executing test for the app and extension
+import pytest
+
+@pytest.fixture
+def cwd_subdit_notebook_url(base_url):
+    return base_url +  "/voila/render/subdir/cwd_subdir"
+
+@pytest.fixture
+def voila_args(notebook_directory, voila_args_extra):
+    return ['--VoilaTest.root_dir=%r' % notebook_directory, '--VoilaTest.log_level=DEBUG'] + voila_args_extra
+
+
+@pytest.mark.gen_test
+def test_hello_world(http_client, cwd_subdit_notebook_url):
+    response = yield http_client.fetch(cwd_subdit_notebook_url)
+    html_text = response.body.decode('utf-8')
+    assert 'check for the cwd' in html_text
+

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -5,9 +5,11 @@
 #                                                                           #
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
+import os
 import tornado.web
 
 from jupyter_server.base.handlers import JupyterHandler
+
 
 import nbformat  # noqa: F401
 from .execute import executenb
@@ -50,9 +52,10 @@ class VoilaHandler(JupyterHandler):
         kernel_name = notebook.metadata.get('kernelspec', {}).get('name', self.kernel_manager.default_kernel_name)
 
         # Launch kernel and execute notebook
-        kernel_id = yield tornado.gen.maybe_future(self.kernel_manager.start_kernel(kernel_name=kernel_name))
+        cwd = os.path.dirname(notebook_path)
+        kernel_id = yield tornado.gen.maybe_future(self.kernel_manager.start_kernel(kernel_name=kernel_name, path=cwd))
         km = self.kernel_manager.get_kernel(kernel_id)
-        result = executenb(notebook, km=km)
+        result = executenb(notebook, km=km, cwd=cwd)
 
         # render notebook to html
         resources = {


### PR DESCRIPTION
closes #118 

This sets the cwd to the os.path.dirname of the notebook path, test are included. 

Note: this tests for both standalone app and the server, which leads to duplicate testst, we might want to reconsider how to do that (although I'm not sure it is possible with pytest-tornado)