### PR TITLE
Progressively render the template using jinja's generate method

### DIFF
--- a/share/jupyter/voila/templates/default/nbconvert_templates/base.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/base.tpl
@@ -19,12 +19,18 @@
     crossorigin="anonymous">
 </script>
 
-<script id="jupyter-config-data" type="application/json">
-{
-    "baseUrl": "{{resources.base_url}}",
-    "kernelId": "{{resources.kernel_id}}"
-}
-</script>
+{% block notebook_execute %}
+    {%- set kernel_id = kernel_start() -%}
+    <script id="jupyter-config-data" type="application/json">
+    {
+        "baseUrl": "{{resources.base_url}}",
+        "kernelId": "{{kernel_id}}"
+    }
+    </script>
+    {# from this point on, nb.cells contains output of the executed cells #}
+    {% do notebook_execute(nb, kernel_id) %}
+{%- endblock notebook_execute -%}
+
 {%- endblock html_head_js -%}
 
 {%- block html_head_css -%}

--- a/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
@@ -7,16 +7,16 @@
 
 
 {%- block html_head_css -%}
-<link rel="stylesheet" type="text/css" href="{{resources.base_url}}voila/static/index.css"></link>
+<link rel="stylesheet" type="text/css" href="{{resources.base_url}}voila/static/index.css">
 
 {% if resources.theme == 'dark' %}
-    <link rel="stylesheet" type="text/css" href="{{resources.base_url}}voila/static/theme-dark.css"></link>
+    <link rel="stylesheet" type="text/css" href="{{resources.base_url}}voila/static/theme-dark.css">
 {% else %}
-    <link rel="stylesheet" type="text/css" href="{{resources.base_url}}voila/static/theme-light.css"></link>
+    <link rel="stylesheet" type="text/css" href="{{resources.base_url}}voila/static/theme-light.css">
 {% endif %}
 
 {% for css in resources.inlining.css %}
-    <style type="text/css">
+    <style>
     {{ css }}
     </style>
 {% endfor %}
@@ -33,7 +33,7 @@ a.anchor-link {
 {{ mathjax() }}
 
   <!-- voila spinner -->
-  <style type="text/css">
+  <style>
     #loading {
         display: flex;
         align-items: center;
@@ -53,7 +53,7 @@ a.anchor-link {
 <body class="jp-Notebook theme-light" data-base-url="{{resources.base_url}}voila/">
 {% endif %}
   <div id="loading">
-    <h2><i class="fa fa-spinner fa-spin" style="font-size:36px;"></i><span id="loading_text">Running {{nb_title}}...</text></i></h2>
+    <h2><i class="fa fa-spinner fa-spin" style="font-size:36px;"></i><span id="loading_text">Running {{nb_title}}...</span></h2>
   </div>
 <script>
 var voila_process = function(cell_index, cell_count) {
@@ -95,6 +95,8 @@ var voila_process = function(cell_index, cell_count) {
 {%- endblock body_loop -%}
 
 {%- block body_footer -%}
+</div>
+
 <script type="text/javascript">
     (function() {
       // remove the loading element

--- a/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
@@ -72,6 +72,12 @@ var voila_process = function(cell_index, cell_count) {
   }
   </script>
   {% set cell_count = nb.cells|length %}
+  {#
+  Voila is using Jinja's Template.generate method to not render the whole template in one go.
+  The current implementation of Jinja will however not yield template snippets if we call a blocks' super()
+  Therefore it is important to have the cell loop in the template.
+  The issue for Jinja is: https://github.com/pallets/jinja/issues/1044
+  #}
   {%- for cell in cell_generator(nb, kernel_id) -%}
     {% set cellloop = loop %}
     {%- block any_cell scoped -%}

--- a/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
@@ -1,6 +1,11 @@
 {%- extends 'base.tpl' -%}
 {% from 'mathjax.tpl' import mathjax %}
 
+{# this overrides the default behaviour of directly starting the kernel and executing the notebook #}
+{% block notebook_execute %}
+{% endblock notebook_execute %}
+
+
 {%- block html_head_css -%}
 <link rel="stylesheet" type="text/css" href="{{resources.base_url}}voila/static/index.css"></link>
 
@@ -26,6 +31,18 @@ a.anchor-link {
 </style>
 
 {{ mathjax() }}
+
+  <!-- voila spinner -->
+  <style type="text/css">
+    #loading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 75vh;
+        color: #444;
+        font-family: sans-serif;
+    }
+  </style>
 {%- endblock html_head_css -%}
 
 {%- block body -%}
@@ -34,7 +51,28 @@ a.anchor-link {
 {% else %}
 <body class="jp-Notebook theme-light" data-base-url="{{resources.base_url}}voila/">
 {% endif %}
-{{ super() }}
+  <div id="loading">
+    <h2><i class="fa fa-spinner fa-spin" style="font-size:36px;"></i> Running {{nb_title}}...</i></h2>
+  </div>
+{# from this point on, the kernel is started #}
+{%- with kernel_id = kernel_start() -%}
+  <script id="jupyter-config-data" type="application/json">
+  {
+      "baseUrl": "{{resources.base_url}}",
+      "kernelId": "{{kernel_id}}"
+  }
+  </script>
+  {# from this point on, nb.cells contains output of the executed cells #}
+  {% do notebook_execute(nb, kernel_id) %}
+    {{ super() }}
+{% endwith %}
+<script type="text/javascript">
+    // remove the loading element
+    (function() {
+      var el = document.getElementById("loading")
+      el.parentNode.removeChild(el)
+    })()
+</script>
 </body>
 {%- endblock body -%}
 

--- a/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
@@ -46,6 +46,7 @@ a.anchor-link {
 {%- endblock html_head_css -%}
 
 {%- block body -%}
+{%- block body_header -%}
 {% if resources.theme == 'dark' %}
 <body class="jp-Notebook theme-dark" data-base-url="{{resources.base_url}}voila/">
 {% else %}
@@ -63,6 +64,9 @@ var voila_process = function(cell_index, cell_count) {
 </script>
 
 <div id="rendered_cells" style="display: none">
+{%- endblock body_header -%}
+
+{%- block body_loop -%}
 {# from this point on, the kernel is started #}
 {%- with kernel_id = kernel_start() -%}
   <script id="jupyter-config-data" type="application/json">
@@ -88,6 +92,9 @@ var voila_process = function(cell_index, cell_count) {
     {%- endblock any_cell -%}
   {%- endfor -%}
 {% endwith %}
+{%- endblock body_loop -%}
+
+{%- block body_footer -%}
 <script type="text/javascript">
     (function() {
       // remove the loading element
@@ -99,5 +106,6 @@ var voila_process = function(cell_index, cell_count) {
     })();
 </script>
 </body>
+{%- endblock body_footer -%}
 {%- endblock body -%}
 

--- a/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
@@ -39,7 +39,7 @@ a.anchor-link {
         align-items: center;
         justify-content: center;
         height: 75vh;
-        color: #444;
+        color: var(--jp-content-font-color1);
         font-family: sans-serif;
     }
   </style>

--- a/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/templates/default/nbconvert_templates/voila.tpl
@@ -57,7 +57,6 @@ a.anchor-link {
   </div>
 <script>
 var voila_process = function(cell_index, cell_count) {
-  console.log(cell_index, "out of", cell_count)
   var el = document.getElementById("loading_text")
   el.innerHTML = `Executing ${cell_index} of ${cell_count}`
 }

--- a/tests/notebooks/print.ipynb
+++ b/tests/notebooks/print.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print('Hi Voila!')"
+    "print('Hi ' +'Voila!')"
    ]
   }
  ],

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -138,6 +138,7 @@ class VoilaHandler(JupyterHandler):
         for html_snippet, resources in exporter.generate_from_notebook_node(notebook, resources=resources, extra_context=extra_context):
             self.write(html_snippet)
             self.flush()  # we may not want to consider not flusing after each snippet, but add an explicit flush function to the jinja context
+            yield  # give control back to tornado's IO loop, so it can handle static files or other requests
         self.flush()
 
     def redirect_to_file(self, path):

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -122,8 +122,10 @@ class VoilaHandler(JupyterHandler):
                 # we don't filter empty cells, since we do not know how many empty code cells we will have
                 yield cell
 
-        # these functions allow the start of a kernel and execution of the notebook after (parts of) the template
+        # These functions allow the start of a kernel and execution of the notebook after (parts of) the template
         # has been rendered and send to the client to allow progressive rendering.
+        # Template should first call kernel_start, and then decide to use notebook_execute
+        # or cell_generator to implement progressive cell rendering
         extra_context = {
             'kernel_start': lambda: kernel_start().result(),  # pass the result (not the future) to the template
             'cell_generator': cell_generator,
@@ -135,7 +137,7 @@ class VoilaHandler(JupyterHandler):
         # render notebook in snippets, and flush them out to the browser can render progresssively
         for html_snippet, resources in exporter.generate_from_notebook_node(notebook, resources=resources, extra_context=extra_context):
             self.write(html_snippet)
-            self.flush()
+            self.flush()  # we may not want to consider not flusing after each snippet, but add an explicit flush function to the jinja context
         self.flush()
 
     def redirect_to_file(self, path):

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -90,7 +90,7 @@ class VoilaHandler(JupyterHandler):
             # Launch kernel and execute notebook
             kernel_id = yield tornado.gen.maybe_future(self.kernel_manager.start_kernel(kernel_name=notebook.metadata.kernelspec.name, path=cwd))
             self.kernel_started = True
-            return kernel_id
+            raise tornado.gen.Return(kernel_id)
 
         @tornado.gen.coroutine
         def notebook_execute(nb, kernel_id):


### PR DESCRIPTION
If you call Template.generate instead of Template.render, jinja returns snippets (for each statement a snippet, not expressions!).
The key here is that:
```
{%- set nb = notebook_execute() -%}
```
Is a statement, so all html before this will be send to the browser (and allows the browser to progressively load, and show a spinner). However, it seems that the nb variable is not updates, the rest of the template seems to use the old 'nb' variable.

Replaces #71 
