### PR TITLE
Dev mode detect

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -302,9 +302,9 @@ class Voila(Application):
                 self.template_paths,
                 self.template)
         self.log.debug('using template: %s', self.template)
-        self.log.debug('nbconvert template paths: %s', self.nbconvert_template_paths)
-        self.log.debug('template paths: %s', self.template_paths)
-        self.log.debug('static paths: %s', self.static_paths)
+        self.log.debug('nbconvert template paths:\n\t%s', '\n\t'.join(self.nbconvert_template_paths))
+        self.log.debug('template paths:\n\t%s', '\n\t'.join(self.template_paths))
+        self.log.debug('static paths:\n\t%s', '\n\t'.join(self.static_paths))
         if self.notebook_path and not os.path.exists(self.notebook_path):
             raise ValueError('Notebook not found: %s' % self.notebook_path)
 

--- a/voila/paths.py
+++ b/voila/paths.py
@@ -12,6 +12,8 @@ from jupyter_core.paths import jupyter_path
 
 ROOT = os.path.dirname(__file__)
 STATIC_ROOT = os.path.join(ROOT, 'static')
+# if the directory above us contains the following paths, it means we are installed in dev mode (pip install -e .)
+DEV_MODE = os.path.exists(os.path.join(ROOT, '../setup.py')) and os.path.exists(os.path.join(ROOT, '../share'))
 
 
 def collect_template_paths(
@@ -35,10 +37,11 @@ def collect_template_paths(
     """
 
     # We look at the usual jupyter locations, and for development purposes also
-    # relative to the package directory (with highest precedence)
-    search_directories = \
-        [os.path.abspath(os.path.join(ROOT, '..', 'share', 'jupyter', 'voila', 'template'))] +\
-        jupyter_path('voila', 'template')
+    # relative to the package directory (first entry, meaning with highest precedence)
+    search_directories = []
+    if DEV_MODE:
+        search_directories.append(os.path.abspath(os.path.join(ROOT, '..', 'share', 'jupyter', 'voila', 'template')))
+    search_directories.extend(jupyter_path('voila', 'template'))
 
     found_at_least_one = False
     for search_directory in search_directories:


### PR DESCRIPTION
 * Closes #135.
 * ~~Needs a rebase after #137~~
 * Includes prettier printing of search paths:
```
[Voila] using template: gridstack
[Voila] nbconvert template paths (\t\n) instead of comma separated lists:
	/Users/maartenbreddels/src/QuantStack/voila/share/jupyter/voila/template/gridstack/nbconvert_templates
	/Users/maartenbreddels/src/QuantStack/voila/share/jupyter/voila/template/default/nbconvert_templates
[Voila] template paths:
	/Users/maartenbreddels/src/QuantStack/voila/share/jupyter/voila/template/gridstack/templates
	/Users/maartenbreddels/src/QuantStack/voila/share/jupyter/voila/template/default/templates
[Voila] static paths:
	/Users/maartenbreddels/src/QuantStack/voila/share/jupyter/voila/template/gridstack/static
	/Users/maartenbreddels/src/QuantStack/voila/share/jupyter/voila/template/default/static
	/Users/maartenbreddels/src/QuantStack/voila/voila/static
```