### PR TITLE
feature(configuration): server extension shares configuration with voila app

### DIFF
--- a/tests/app/config_paths_test.py
+++ b/tests/app/config_paths_test.py
@@ -14,7 +14,7 @@ def voila_config_file_paths_arg():
 
 
 def test_config_app(voila_app):
-    assert voila_app.template == 'gridstack'
+    assert voila_app.voila_configuration.template == 'gridstack'
 
 
 def test_config_kernel_manager(voila_app):

--- a/tests/app/execute_test.py
+++ b/tests/app/execute_test.py
@@ -17,6 +17,7 @@ def test_hello_world(http_client, base_url):
     assert response.code == 200
     html_text = response.body.decode('utf-8')
     assert 'Hi Voila' in html_text
+    assert 'print' not in html_text, 'by default the source code should be stripped'
     assert 'gridstack.css' not in html_text, "gridstack should not be the default"
 
 

--- a/tests/app/no_strip_sources_test.py
+++ b/tests/app/no_strip_sources_test.py
@@ -1,0 +1,20 @@
+import pytest
+import json
+import os
+
+
+BASE_DIR = os.path.dirname(__file__)
+
+
+@pytest.fixture
+def voila_args_extra():
+    return ['--VoilaConfiguration.strip_sources=False']
+
+
+@pytest.mark.gen_test
+def test_template_gridstack(http_client, base_url):
+    response = yield http_client.fetch(base_url)
+    assert response.code == 200
+    html_text = response.body.decode('utf-8')
+    assert 'Hi Voila' in html_text
+    assert 'print' in html_text, 'the source code should *NOT* be stripped'

--- a/tests/configs/general/voila.json
+++ b/tests/configs/general/voila.json
@@ -1,5 +1,5 @@
 {
-    "Voila": {
+    "VoilaConfiguration": {
         "template": "gridstack"
     },
     "MappingKernelManager": {

--- a/tests/server/no_strip_sources_test.py
+++ b/tests/server/no_strip_sources_test.py
@@ -1,14 +1,14 @@
-# test basics of voila running a notebook
 import pytest
-import tornado.web
-import tornado.gen
-import re
 import json
+import os
 
-try:
-    from unittest import mock
-except:
-    import mock
+
+BASE_DIR = os.path.dirname(__file__)
+
+
+@pytest.fixture
+def jupyter_server_args_extra():
+    return ['--VoilaConfiguration.strip_sources=False']
 
 
 @pytest.mark.gen_test
@@ -17,5 +17,6 @@ def test_hello_world(http_client, print_notebook_url):
     assert response.code == 200
     html_text = response.body.decode('utf-8')
     assert 'Hi Voila' in html_text
-    assert 'print' not in html_text, 'by default the source code should be stripped'
+    assert 'print' in html_text, 'the source code should *NOT* be stripped'
     assert 'gridstack.css' not in html_text, "gridstack should not be the default"
+

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -1,0 +1,24 @@
+#############################################################################
+# Copyright (c) 2018, Voila Contributors                                    #
+#                                                                           #
+# Distributed under the terms of the BSD 3-Clause License.                  #
+#                                                                           #
+# The full license is in the file LICENSE, distributed with this software.  #
+#############################################################################
+
+import traitlets.config
+from traitlets import Unicode, Bool
+
+
+class VoilaConfiguration(traitlets.config.Configurable):
+    """Common configuration options between the server extension and the application."""
+    template = Unicode(
+        'default',
+        config=True,
+        allow_none=True,
+        help=(
+            'template name to be used by voila.'
+        )
+    )
+    theme = Unicode('light').tag(config=True)
+    strip_sources = Bool(True, help='Strip sources from rendered html').tag(config=True)

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -21,11 +21,9 @@ class VoilaHandler(JupyterHandler):
 
     def initialize(self, **kwargs):
         self.notebook_path = kwargs.pop('notebook_path', [])    # should it be []
-        self.strip_sources = kwargs.pop('strip_sources', True)
         self.nbconvert_template_paths = kwargs.pop('nbconvert_template_paths', [])
-        self.template_name = kwargs.pop('template_name', 'default')
         self.exporter_config = kwargs.pop('config', None)
-        self.theme = kwargs.pop('theme', 'light')
+        self.voila_configuration = kwargs['voila_configuration']
 
     @tornado.web.authenticated
     @tornado.gen.coroutine
@@ -64,7 +62,7 @@ class VoilaHandler(JupyterHandler):
             'kernel_id': kernel_id,
             'base_url': self.base_url,
             'nbextensions': nbextensions,
-            'theme': self.theme
+            'theme': self.voila_configuration.theme
         }
 
         exporter = VoilaExporter(
@@ -73,7 +71,7 @@ class VoilaHandler(JupyterHandler):
             contents_manager=self.contents_manager  # for the image inlining
         )
 
-        if self.strip_sources:
+        if self.voila_configuration.strip_sources:
             exporter.exclude_input = True
             exporter.exclude_output_prompt = True
             exporter.exclude_input_prompt = True

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -19,6 +19,7 @@ from .paths import ROOT, STATIC_ROOT, collect_template_paths, jupyter_path
 from .handler import VoilaHandler
 from .treehandler import VoilaTreeHandler
 from .static_file_handler import MultiStaticFileHandler
+from .configuration import VoilaConfiguration
 
 
 def load_jupyter_server_extension(server_app):
@@ -28,11 +29,13 @@ def load_jupyter_server_extension(server_app):
     static_paths = [STATIC_ROOT]
     template_paths = []
 
+    # common configuration options between the server extension and the application
+    voila_configuration = VoilaConfiguration(parent=server_app)
     collect_template_paths(
         nbconvert_template_paths,
         static_paths,
         template_paths,
-        'default'
+        voila_configuration.template
     )
 
     jenv_opt = {"autoescape": True}
@@ -54,6 +57,7 @@ def load_jupyter_server_extension(server_app):
         (url_path_join(base_url, '/voila/render' + path_regex), VoilaHandler, {
             'config': server_app.config,
             'nbconvert_template_paths': nbconvert_template_paths,
+            'voila_configuration': voila_configuration
         }),
         (url_path_join(base_url, '/voila'), VoilaTreeHandler),
         (url_path_join(base_url, '/voila/tree' + path_regex), VoilaTreeHandler),


### PR DESCRIPTION
Before, only `Voila` was configurable, but options should also be configurable for the server extension. These common options/traits should now go into `VoilaConfiguration` (spelled out completely to avoid confusion with the traitlet `Config` class).
Examples:
```
$ jupyter server --VoilaConfiguration.template=default --VoilaConfiguration.theme=dark
$ jupyter notebook --no-browser --VoilaConfiguration.template=gridstack
```
For voila, the `--template` is an alias, so these two are equivalent
```
$ voila . --no-browser --VoilaConfiguration.template=gridstack
$ voila . --no-browser --template=gridstack
```

Docs should reflect this (maybe @choldgraf wants to be involved here), we could do this in a separate PR.
# TODO
 - [x] `strip_sources` should move to this class
 - [x] more tests