### PR TITLE
Remove locally built css

### DIFF
--- a/js/css/widgets.css
+++ b/js/css/widgets.css
@@ -1,1 +1,0 @@
-@import "@jupyter-widgets/controls/css/widgets.built.css";

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -6,9 +6,5 @@
 * The full license is in the file LICENSE, distributed with this software. *
 ****************************************************************************/
 
-import 'font-awesome/css/font-awesome.css'
-import '@phosphor/widgets/style/index.css'
-import '../css/widgets.css'
-
 export { WidgetManager } from './manager';
 export { connectKernel } from './kernel'


### PR DESCRIPTION
This removes the inlined CSS from `@phosphor/widgets` and the `@jupyter-widgets/controls`.

The latter was substituting CSS variables with default values from the light theme.