### PR TITLE
chore(deps,js): move to jupyterlab-manager 0.40

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
     "@jupyter-widgets/base": "^1.2.2",
     "@jupyter-widgets/controls": "^1.4.2",
     "@jupyter-widgets/html-manager": "^0.15.2",
-    "@jupyter-widgets/jupyterlab-manager": "^0.39.1",
+    "@jupyter-widgets/jupyterlab-manager": "^0.40.0",
     "@jupyter-widgets/output": "^1.1.2",
     "@jupyterlab/coreutils": "^2.2.1",
     "@jupyterlab/outputarea": "^0.19.1",

--- a/js/src/manager.js
+++ b/js/src/manager.js
@@ -27,8 +27,9 @@ export class WidgetManager extends JupyterLabManager {
 
     constructor(kernel) {
         const context = createContext(kernel);
+        const settings = createSettings();
         const rendermime = createRenderMimeRegistry();
-        super(context, rendermime);
+        super(context, rendermime, settings);
         this._registerWidgets();
         this.loader = requireLoader;
     }
@@ -71,6 +72,9 @@ export class WidgetManager extends JupyterLabManager {
                 }
             })
         }
+    }
+
+    restoreWidgets(notebook) {
     }
 
     _registerWidgets() {
@@ -137,9 +141,19 @@ function createContext(kernel) {
             kernel,
             kernelChanged: {
                 connect: () => {}
-            }
-        }
+            },
+            statusChanged: {
+                connect: () => {}
+            },
+        },
+        saveState: {
+            connect: () => {}
+        },
     };
+}
+
+function createSettings() {
+    return {};
 }
 
 function createRenderMimeRegistry() {


### PR DESCRIPTION
Change in https://github.com/jupyter-widgets/ipywidgets/pull/2265 caused voila to break, as noted by @SylvainCorlay.
In order to test if https://github.com/jupyter-widgets/ipywidgets/pull/2418 works in voila, we first need to move to manager 0.40.

