### PR TITLE
Use jupyterlab_pygments to generate syntax coloring CSS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server pytest==3.10.1 pytest-cov nodejs flake8 ipywidgets
+  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server==0.0.5 jupyterlab_pygments==0.1.0 pytest==3.10.1 pytest-cov nodejs flake8 ipywidgets
   - source activate test-environment
 install:
   - pip install ".[test]"

--- a/setup.py
+++ b/setup.py
@@ -264,8 +264,9 @@ setup_args = {
         ]
     },
     'install_requires': [
-        'jupyter_server>=0.0.4',
-        'nbconvert>=5.5.0,<6'
+        'jupyter_server>=0.0.5,<0.0.6',
+        'nbconvert>=5.5.0,<6',
+        'jupyterlab_pygments>=0.1.0,<0.2'
     ],
     'extras_require': {
         'test': ['mock', 'pytest<4', 'pytest-tornado5']

--- a/voila/csspreprocessor.py
+++ b/voila/csspreprocessor.py
@@ -8,7 +8,10 @@
 
 import hashlib
 
-from traitlets import Unicode
+from traitlets import Unicode, Union, Type
+from pygments.style import Style
+from jupyterlab_pygments import JupyterStyle
+
 from nbconvert.preprocessors.base import Preprocessor
 
 try:
@@ -25,8 +28,9 @@ class VoilaCSSPreprocessor(Preprocessor):
     highlight_class = Unicode('.highlight',
                               help="CSS highlight class identifier").tag(config=True)
 
-    # style = Unicode('default',
-    #                 help='Name of the pygments style to use').tag(config=True)
+    style = Union([Unicode('default'), Type(klass=Style)],
+                  help='Name of the pygments style to use',
+                  default_value=JupyterStyle).tag(config=True)
 
     def __init__(self, *pargs, **kwargs):
         Preprocessor.__init__(self, *pargs, **kwargs)
@@ -60,52 +64,9 @@ class VoilaCSSPreprocessor(Preprocessor):
 
         # Add pygments CSS
 
-        # from pygments.formatters import HtmlFormatter
-        # formatter = HtmlFormatter(style=self.style)
-        # pygments_css = formatter.get_style_defs(self.highlight_class)
-
-        pygments_css = '''
-.highlight .hll { background-color: var(--jp-cell-editor-active-background) }
-.highlight  { background: var(--jp-cell-editor-background); }
-.highlight .c { color: var(--jp-mirror-editor-comment-color) } /* Comment */
-.highlight .err { color: var(--jp-mirror-editor-error-color) } /* Error */
-.highlight .k { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword */
-.highlight .o { color: var(--jp-mirror-editor-operator-color) } /* Operator */
-.highlight .ch { color: var(--jp-mirror-editor-comment-color) } /* Comment.Hashbang */
-.highlight .cm { color: var(--jp-mirror-editor-comment-color) } /* Comment.Multiline */
-.highlight .cp { color: var(--jp-mirror-editor-comment-color) } /* Comment.Preproc */
-.highlight .cpf { color: var(--jp-mirror-editor-comment-color) } /* Comment.PreprocFile */
-.highlight .c1 { color: var(--jp-mirror-editor-comment-color) } /* Comment.Single */
-.highlight .cs { color: var(--jp-mirror-editor-comment-color) } /* Comment.Special */
-.highlight .kc { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Constant */
-.highlight .kd { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Declaration */
-.highlight .kn { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Namespace */
-.highlight .kp { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Pseudo */
-.highlight .kr { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Reserved */
-.highlight .kt { color: var(--jp-mirror-editor-keyword-color); font-weight: bold } /* Keyword.Type */
-.highlight .m { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number */
-.highlight .s { color: var(--jp-mirror-editor-string-color) } /* Literal.String */
-.highlight .ow { color: var(--jp-mirror-editor-operator-color) } /* Operator.Word */
-.highlight .mb { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Bin */
-.highlight .mf { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Float */
-.highlight .mh { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Hex */
-.highlight .mi { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Integer */
-.highlight .mo { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Oct */
-.highlight .sa { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Affix */
-.highlight .sb { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Backtick */
-.highlight .sc { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Char */
-.highlight .dl { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Delimiter */
-.highlight .sd { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Doc */
-.highlight .s2 { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Double */
-.highlight .se { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Escape */
-.highlight .sh { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Heredoc */
-.highlight .si { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Interpol */
-.highlight .sx { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Other */
-.highlight .sr { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Regex */
-.highlight .s1 { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Single */
-.highlight .ss { color: var(--jp-mirror-editor-string-color) } /* Literal.String.Symbol */
-.highlight .il { color: var(--jp-mirror-editor-number-color); font-weight: bold } /* Literal.Number.Integer.Long */
-'''
+        from pygments.formatters import HtmlFormatter
+        formatter = HtmlFormatter(style=self.style)
+        pygments_css = formatter.get_style_defs(self.highlight_class)
         header.append(pygments_css)
 
         return header


### PR DESCRIPTION
Since `pygments` 2.4.1 is out, I could release `jupyterlab_pygments` and make use of it.