### PR TITLE
Enable bqplot 0.11.x themes

### DIFF
--- a/share/jupyter/voila/template/default/nbconvert_templates/voila.tpl
+++ b/share/jupyter/voila/template/default/nbconvert_templates/voila.tpl
@@ -29,7 +29,11 @@ a.anchor-link {
 {%- endblock html_head_css -%}
 
 {%- block body -%}
-<body class="jp-Notebook" data-base-url="{{resources.base_url}}voila/">
+{% if resources.theme == 'dark' %}
+<body class="jp-Notebook theme-dark" data-base-url="{{resources.base_url}}voila/">
+{% else %}
+<body class="jp-Notebook theme-light" data-base-url="{{resources.base_url}}voila/">
+{% endif %}
 {{ super() }}
 </body>
 {%- endblock body -%}


### PR DESCRIPTION
I am not 100% sure this should get into `voila` core.

Basically, this automatically enables the dark bqplot theme (of bqplot <0.12) by adding the `theme-dark` class to `body` when the selected theme is dark.

cc @aschlaep @jasongrout @maartenbreddels 