### PR TITLE
add top-level serverextension and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Voila can also be used as a notebook server extension, both with the
 [notebook](https://github.com/jupyter/notebook) server or with
 [jupyter_server](https://github.com/jupyter/jupyter_server).
 
+To install the notebook server extension, run
+
+```
+jupyter serverextension enable voila.server_extension
+```
+
+You may wish to add `--sys-prefix` to the previous command if you are running it
+inside of a conda environment or a virtualenv, to enable voila only for that
+environment.
+
 When running the notebook server, the voila app is accessible from the base url
 suffixed with `voila`.
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,8 @@ Voila can also be used as a notebook server extension, both with the
 To install the notebook server extension, run
 
 ```
-jupyter serverextension enable voila.server_extension
+jupyter serverextension enable voila --sys-prefix
 ```
-
-You may wish to add `--sys-prefix` to the previous command if you are running it
-inside of a conda environment or a virtualenv, to enable voila only for that
-environment.
 
 When running the notebook server, the voila app is accessible from the base url
 suffixed with `voila`.

--- a/voila/__init__.py
+++ b/voila/__init__.py
@@ -7,6 +7,7 @@
 #############################################################################
 
 from ._version import __version__  # noqa
+from .server_extension import load_jupyter_server_extension  # noqa
 
 
 def _jupyter_nbextension_paths():


### PR DESCRIPTION
Here's what the output looks like with these modest changes
```
$ jupyter serverextension enable voila
Enabling: voila
- Writing config: /home/pi/.jupyter
    - Validating...
      voila 0.0.13 OK
```

and 

```
$ jupyter serverextension list
config dir: /home/pi/.jupyter
    voila  enabled
    - Validating...
      voila 0.0.13 OK
```