### PR TITLE
don't 500 on cell execution errors

### DIFF
--- a/voila/execute.py
+++ b/voila/execute.py
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
 
-from nbconvert.preprocessors.execute import ExecutePreprocessor
+from nbconvert.preprocessors.execute import CellExecutionError, ExecutePreprocessor
 from ipykernel.jsonutil import json_clean
 
 
@@ -83,7 +83,12 @@ class ExecutePreprocessorWithOutputWidget(ExecutePreprocessor):
     def preprocess(self, nb, resources, km=None):
         self.output_hook = {}
         self.output_objects = {}
-        return super(ExecutePreprocessorWithOutputWidget, self).preprocess(nb, resources=resources, km=km)
+        try:
+            result = super(ExecutePreprocessorWithOutputWidget, self).preprocess(nb, resources=resources, km=km)
+        except CellExecutionError as e:
+            self.log.error(e)
+            result = (nb, resources)
+        return result
 
     def output(self, outs, msg, display_id, cell_index):
         parent_msg_id = msg['parent_header'].get('msg_id')


### PR DESCRIPTION
Sometimes, code execution will error (for example, missing dependencies), and it's rough to get 500 errors in the browser and have to look in the console where the server was started to see what the error was. This code leaves in-place the error presented in the notebook when executing that particular cell, and continues to log in on the server-side, but without causing a server 500 error.