### PR TITLE
JupyterLab extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ share/jupyter/voila/templates/default/static/*voila.js
 share/jupyter/voila/templates/default/static/*[woff|woff2|eot|svg]
 
 js/lib/
+
+packages/jupyterlab-voila/lib/

--- a/packages/jupyterlab-voila/package.json
+++ b/packages/jupyterlab-voila/package.json
@@ -25,33 +25,49 @@
   },
   "scripts": {
     "build": "tsc",
+    "prettier": "prettier --write '**/*{.ts,.tsx,.js,.jsx,.css,.json,.md}'",
     "clean": "rimraf lib",
     "watch": "tsc -w",
     "prepare": "npm run clean && npm run build"
   },
+  "dependencies": {
+    "@jupyterlab/application": "^0.19.0",
+    "@jupyterlab/apputils": "^0.19.0",
+    "@jupyterlab/docregistry": "^0.19.0",
+    "@jupyterlab/fileeditor": "^0.19.0",
+    "@jupyterlab/mainmenu": "^0.8.1",
+    "@jupyterlab/notebook": "^0.19.0"
+  },
   "peerDependencies": {
     "@jupyterlab/application": "^0.19.0",
     "@jupyterlab/apputils": "^0.19.0",
-    "@jupyterlab/notebook": "^0.19.0",
-    "@jupyterlab/mainmenu": "^0.19.0",
     "@jupyterlab/docregistry": "^0.19.0",
-    "@jupyterlab/fileeditor": "^0.19.0"
+    "@jupyterlab/fileeditor": "^0.19.0",
+    "@jupyterlab/mainmenu": "^0.8.1",
+    "@jupyterlab/notebook": "^0.19.0"
   },
   "devDependencies": {
+    "husky": "^2.3.0",
+    "lint-staged": "^7.3.0",
+    "prettier": "^1.13.7",
     "rimraf": "^2.6.1",
-    "typescript": "~2.9.2",
-    "@jupyterlab/application": "^0.19.0",
-    "@jupyterlab/apputils": "^0.19.0",
-    "@jupyterlab/notebook": "^0.19.0",
-    "@jupyterlab/mainmenu": "^0.19.0",
-    "@jupyterlab/docregistry": "^0.19.0",
-    "@jupyterlab/fileeditor": "^0.19.0"
+    "tslint": "^5.10.0",
+    "tslint-config-prettier": "^1.13.0",
+    "tslint-plugin-prettier": "^1.3.0",
+    "typescript": "~2.9.2"
+  },
+  "lint-staged": {
+    "**/*{.ts,.tsx,.css,.json,.md}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   },
   "jupyterlab": {
     "extension": true
-  },
-  "dependencies": {
-    "@jupyterlab/application": "^0.19.0",
-    "@jupyterlab/mainmenu": "^0.8.0"
   }
 }

--- a/packages/jupyterlab-voila/package.json
+++ b/packages/jupyterlab-voila/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "jupyterlab-voila",
+  "version": "0.1.0",
+  "description": "A JupyterLab extension for Voila",
+  "keywords": [
+    "jupyter",
+    "jupyterlab",
+    "jupyterlab-extension"
+  ],
+  "homepage": "https://github.com/QuantStack/voila",
+  "bugs": {
+    "url": "https://github.com/QuantStack/voila/issues"
+  },
+  "license": "BSD-3-Clause",
+  "author": "Maarten Breddels, Sylvain Corlay",
+  "files": [
+    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
+    "style/**/*.{css,eot,gif,html,jpg,json,png,svg,woff2,ttf}"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/QuantStack/voila.git"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rimraf lib",
+    "watch": "tsc -w",
+    "prepare": "npm run clean && npm run build"
+  },
+  "peerDependencies": {
+    "@jupyterlab/application": "^0.19.0",
+    "@jupyterlab/apputils": "^0.19.0",
+    "@jupyterlab/notebook": "^0.19.0",
+    "@jupyterlab/mainmenu": "^0.19.0",
+    "@jupyterlab/docregistry": "^0.19.0",
+    "@jupyterlab/fileeditor": "^0.19.0"
+  },
+  "devDependencies": {
+    "rimraf": "^2.6.1",
+    "typescript": "~2.9.2",
+    "@jupyterlab/application": "^0.19.0",
+    "@jupyterlab/apputils": "^0.19.0",
+    "@jupyterlab/notebook": "^0.19.0",
+    "@jupyterlab/mainmenu": "^0.19.0",
+    "@jupyterlab/docregistry": "^0.19.0",
+    "@jupyterlab/fileeditor": "^0.19.0"
+  },
+  "jupyterlab": {
+    "extension": true
+  },
+  "dependencies": {
+    "@jupyterlab/application": "^0.19.0",
+    "@jupyterlab/mainmenu": "^0.8.0"
+  }
+}

--- a/packages/jupyterlab-voila/package.json
+++ b/packages/jupyterlab-voila/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^0.19.0",
-    "@jupyterlab/mainmenu": "^0.8.0",
-    "@jupyterlab/docmanager": "^0.19.1"
+    "@jupyterlab/mainmenu": "^0.8.0"
   }
 }

--- a/packages/jupyterlab-voila/package.json
+++ b/packages/jupyterlab-voila/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^0.19.0",
-    "@jupyterlab/mainmenu": "^0.8.0"
+    "@jupyterlab/mainmenu": "^0.8.0",
+    "@jupyterlab/docmanager": "^0.19.1"
   }
 }

--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -39,6 +39,8 @@ export namespace CommandIDs {
     export const voilaOpen = "notebook:open-with-voila";
 }
 
+const VOILA_ICON_CLASS = 'jp-MaterialIcon jp-VoilaIcon';
+
 class VoilaRenderButton implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
 
   constructor(app: JupyterLab) {
@@ -54,9 +56,8 @@ class VoilaRenderButton implements DocumentRegistry.IWidgetExtension<NotebookPan
 
     let button = new ToolbarButton({
       className: 'voilaRender',
-      iconClassName: 'fa fa-desktop',
+      iconClassName: VOILA_ICON_CLASS,
       onClick: renderVoila,
-      label: 'Voila',
       tooltip: 'Render with Voila'
     });
 
@@ -101,6 +102,7 @@ const extension: JupyterLabPlugin<void> = {
 
       content.url = url;
       content.title.label = text;
+      content.title.icon = VOILA_ICON_CLASS;
       content.id = `voila-${++counter}`;
       let widget = new MainAreaWidget({ content });
       return widget;
@@ -121,7 +123,7 @@ const extension: JupyterLabPlugin<void> = {
           const voilaPath = current.context.path;
           const voilaUrl = getVoilaUrl(voilaPath);
           const name = PathExt.basename(voilaPath);
-          let widget = voilaIFrame(voilaUrl, `Voila: ${name}`);
+          let widget = voilaIFrame(voilaUrl, name);
           app.shell.addToMainArea(widget, { mode: 'split-right'});
           return widget;
         },

--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -1,67 +1,59 @@
-import {
-  JupyterLab, JupyterLabPlugin
-} from '@jupyterlab/application';
+import { JupyterLab, JupyterLabPlugin } from "@jupyterlab/application";
 
 import {
-  INotebookTracker, NotebookPanel, INotebookModel
-} from '@jupyterlab/notebook';
+  INotebookTracker,
+  NotebookPanel,
+  INotebookModel
+} from "@jupyterlab/notebook";
 
-import {
-  ReadonlyJSONObject
-} from '@phosphor/coreutils';
+import { ReadonlyJSONObject } from "@phosphor/coreutils";
 
-import {
-    ICommandPalette, MainAreaWidget, IFrame,
-} from '@jupyterlab/apputils';
+import { ICommandPalette, MainAreaWidget, IFrame } from "@jupyterlab/apputils";
 
-import {
-  IMainMenu
-} from '@jupyterlab/mainmenu';
+import { IMainMenu } from "@jupyterlab/mainmenu";
 
-import {
-  PageConfig, PathExt
-} from '@jupyterlab/coreutils';	
+import { PageConfig, PathExt } from "@jupyterlab/coreutils";
 
-import {
-  ToolbarButton
-} from '@jupyterlab/apputils';
+import { ToolbarButton } from "@jupyterlab/apputils";
 
 import { DocumentRegistry } from "@jupyterlab/docregistry";
 
-import { IDisposable } from '@phosphor/disposable';
+import { IDisposable } from "@phosphor/disposable";
 
-import '../style/index.css';
+import "../style/index.css";
 
 export namespace CommandIDs {
+  export const voilaRender = "notebook:render-with-voila";
 
-    export const voilaRender = 'notebook:render-with-voila';
-
-    export const voilaOpen = "notebook:open-with-voila";
+  export const voilaOpen = "notebook:open-with-voila";
 }
 
-const VOILA_ICON_CLASS = 'jp-MaterialIcon jp-VoilaIcon';
+const VOILA_ICON_CLASS = "jp-MaterialIcon jp-VoilaIcon";
 
-class VoilaRenderButton implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
-
+class VoilaRenderButton
+  implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
   constructor(app: JupyterLab) {
     this.app = app;
   }
 
   readonly app: JupyterLab;
 
-  createNew(panel: NotebookPanel, context: DocumentRegistry.IContext<INotebookModel>): IDisposable {
+  createNew(
+    panel: NotebookPanel,
+    context: DocumentRegistry.IContext<INotebookModel>
+  ): IDisposable {
     let renderVoila = () => {
-      this.app.commands.execute('notebook:render-with-voila');
+      this.app.commands.execute("notebook:render-with-voila");
     };
 
     let button = new ToolbarButton({
-      className: 'voilaRender',
+      className: "voilaRender",
       iconClassName: VOILA_ICON_CLASS,
       onClick: renderVoila,
-      tooltip: 'Render with Voila'
+      tooltip: "Render with Voila"
     });
 
-    panel.toolbar.insertItem(9, 'voilaRender', button);
+    panel.toolbar.insertItem(9, "voilaRender", button);
 
     return button;
   }
@@ -71,28 +63,32 @@ class VoilaRenderButton implements DocumentRegistry.IWidgetExtension<NotebookPan
  * Initialization data for the jupyterlab-voila extension.
  */
 const extension: JupyterLabPlugin<void> = {
-  id: 'jupyterlab-voila',
+  id: "jupyterlab-voila",
   autoStart: true,
   requires: [INotebookTracker],
   optional: [ICommandPalette, IMainMenu],
-  activate: (app: JupyterLab, notebooks: INotebookTracker, palette: ICommandPalette, menu: IMainMenu | null) => {
-
+  activate: (
+    app: JupyterLab,
+    notebooks: INotebookTracker,
+    palette: ICommandPalette,
+    menu: IMainMenu | null
+  ) => {
     function getCurrent(args: ReadonlyJSONObject): NotebookPanel | null {
-        const widget = notebooks.currentWidget;
-        const activate = args['activate'] !== false;
+      const widget = notebooks.currentWidget;
+      const activate = args["activate"] !== false;
 
-        if (activate && widget) {
-          app.shell.activateById(widget.id);
-        }
+      if (activate && widget) {
+        app.shell.activateById(widget.id);
+      }
 
-        return widget;
+      return widget;
     }
 
     function isEnabled(): boolean {
-        return (
-          notebooks.currentWidget !== null &&
-          notebooks.currentWidget === app.shell.currentWidget
-        );
+      return (
+        notebooks.currentWidget !== null &&
+        notebooks.currentWidget === app.shell.currentWidget
+      );
     }
 
     let counter = 0;
@@ -109,64 +105,63 @@ const extension: JupyterLabPlugin<void> = {
     }
 
     function getVoilaUrl(path: string): string {
-        const baseUrl = PageConfig.getBaseUrl();
-        return `${baseUrl}voila/render/${path}`;
+      const baseUrl = PageConfig.getBaseUrl();
+      return `${baseUrl}voila/render/${path}`;
     }
 
     app.commands.addCommand(CommandIDs.voilaRender, {
-        label: 'Render Notebook with Voila',
-        execute: async (args) => {
-          const current = getCurrent(args);
-          if (!current) {
-            return;
-          }
-          const voilaPath = current.context.path;
-          const voilaUrl = getVoilaUrl(voilaPath);
-          const name = PathExt.basename(voilaPath);
-          let widget = voilaIFrame(voilaUrl, name);
-          app.shell.addToMainArea(widget, { mode: 'split-right'});
-          return widget;
-        },
-        isEnabled
+      label: "Render Notebook with Voila",
+      execute: async args => {
+        const current = getCurrent(args);
+        if (!current) {
+          return;
+        }
+        const voilaPath = current.context.path;
+        const voilaUrl = getVoilaUrl(voilaPath);
+        const name = PathExt.basename(voilaPath);
+        let widget = voilaIFrame(voilaUrl, name);
+        app.shell.addToMainArea(widget, { mode: "split-right" });
+        return widget;
+      },
+      isEnabled
     });
 
     app.commands.addCommand(CommandIDs.voilaOpen, {
-        label: 'Open with Voila in New Browser Tab',
-        execute: async (args) => {
-          const current = getCurrent(args);
-          if (!current) {
-            return;
-          }
-          const voilaUrl = getVoilaUrl(current.context.path);
-          window.open(voilaUrl);
-        },
-        isEnabled
+      label: "Open with Voila in New Browser Tab",
+      execute: async args => {
+        const current = getCurrent(args);
+        if (!current) {
+          return;
+        }
+        const voilaUrl = getVoilaUrl(current.context.path);
+        window.open(voilaUrl);
+      },
+      isEnabled
     });
 
     if (palette) {
-      const category = 'Notebook Operations';
-      [
-        CommandIDs.voilaRender,
-        CommandIDs.voilaOpen,
-      ].forEach(command => {
-        palette.addItem({ command, category })
+      const category = "Notebook Operations";
+      [CommandIDs.voilaRender, CommandIDs.voilaOpen].forEach(command => {
+        palette.addItem({ command, category });
       });
     }
 
     if (menu) {
-      menu.viewMenu.addGroup([
-        {
-          command: CommandIDs.voilaRender
-        },
-        {
-          command: CommandIDs.voilaOpen
-        }
-      ], 1000);
+      menu.viewMenu.addGroup(
+        [
+          {
+            command: CommandIDs.voilaRender
+          },
+          {
+            command: CommandIDs.voilaOpen
+          }
+        ],
+        1000
+      );
     }
 
     let voilaButton = new VoilaRenderButton(app);
-    app.docRegistry.addWidgetExtension('Notebook', voilaButton);
-    
+    app.docRegistry.addWidgetExtension("Notebook", voilaButton);
   }
 };
 

--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -1,0 +1,88 @@
+import {
+  JupyterLab, JupyterLabPlugin
+} from '@jupyterlab/application';
+
+import {
+  INotebookTracker, NotebookPanel
+} from '@jupyterlab/notebook';
+
+import {
+  ReadonlyJSONObject
+} from '@phosphor/coreutils';
+
+import {
+    ICommandPalette,
+} from '@jupyterlab/apputils';
+
+import {
+  IMainMenu
+} from '@jupyterlab/mainmenu';
+
+import {
+  PageConfig
+} from '@jupyterlab/coreutils';	
+
+import '../style/index.css';
+
+
+/**
+ * Initialization data for the jupyterlab-voila extension.
+ */
+const extension: JupyterLabPlugin<void> = {
+  id: 'jupyterlab-voila',
+  autoStart: true,
+  requires: [INotebookTracker, ICommandPalette, IMainMenu],
+  activate: (app: JupyterLab, notebooks: INotebookTracker, palette: ICommandPalette, menu: IMainMenu | null) => {
+    console.log('JupyterLab extension jupyterlab-voila is activated!!!!!!!!');
+
+    function getCurrent(args: ReadonlyJSONObject): NotebookPanel | null {
+        const widget = notebooks.currentWidget;
+        const activate = args['activate'] !== false;
+
+        if (activate && widget) {
+          app.shell.activateById(widget.id);
+        }
+
+        return widget;
+    }
+
+    function isEnabled(): boolean {
+        return (
+          notebooks.currentWidget !== null &&
+          notebooks.currentWidget === app.shell.currentWidget
+        );
+    }
+
+    app.commands.addCommand(CommandIDs.voilaRender, {
+        label: 'Open/Render Notebook with Voila',
+        execute: async (args) => {
+          const current = getCurrent(args);
+
+          if (current) {
+            const notebookPath = current.context.path;
+            const voilaPath = notebookPath.slice(0, notebookPath.length-6);  // without .ipynb
+            const baseUrl = PageConfig.getBaseUrl();
+            const voilaUrl = baseUrl + "voila/render/" + voilaPath;
+            window.open(voilaUrl)
+          }
+        },
+        isEnabled
+    });
+    palette.addItem({command:CommandIDs.voilaRender, category:'Notebook Operations'})
+
+
+    // TODO: what would be a good place to add it to the menu?
+    // menu.fileMenu.addGroup(
+    //     [
+    //       { command: CommandIDs.voilaRender },
+    //     ],
+    //     1000
+    // );
+    
+  }
+};
+
+export default extension;
+export namespace CommandIDs{
+    export const voilaRender = 'notebook:render-with-voila'
+}

--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -19,7 +19,7 @@ import {
 } from '@jupyterlab/mainmenu';
 
 import {
-  PageConfig
+  PageConfig, PathExt
 } from '@jupyterlab/coreutils';	
 
 import {
@@ -103,15 +103,18 @@ const extension: JupyterLabPlugin<void> = {
         execute: async (args) => {
           const current = getCurrent(args);
 
-          if (current) {
-            const voilaPath = current.context.path;
-            const baseUrl = PageConfig.getBaseUrl();
-            const voilaUrl = baseUrl + "voila/render/" + voilaPath;
-
-            let widget = voilaIFrame(voilaUrl, "Voila");
-            app.shell.addToMainArea(widget, { mode: 'split-right'});
-            return widget;
+          if (!current) {
+            return;
           }
+
+          const voilaPath = current.context.path;
+          const baseUrl = PageConfig.getBaseUrl();
+          const voilaUrl = `${baseUrl}voila/render/${voilaPath}`;
+
+          const name = PathExt.basename(voilaPath);
+          let widget = voilaIFrame(voilaUrl, `Voila: ${name}`);
+          app.shell.addToMainArea(widget, { mode: 'split-right'});
+          return widget;
         },
         isEnabled
     });

--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -65,7 +65,8 @@ class VoilaRenderButton implements DocumentRegistry.IWidgetExtension<NotebookPan
 const extension: JupyterLabPlugin<void> = {
   id: 'jupyterlab-voila',
   autoStart: true,
-  requires: [INotebookTracker, ICommandPalette, IMainMenu],
+  requires: [INotebookTracker],
+  optional: [ICommandPalette, IMainMenu],
   activate: (app: JupyterLab, notebooks: INotebookTracker, palette: ICommandPalette, menu: IMainMenu | null) => {
 
     function getCurrent(args: ReadonlyJSONObject): NotebookPanel | null {
@@ -119,16 +120,21 @@ const extension: JupyterLabPlugin<void> = {
         isEnabled
     });
 
-    palette.addItem({command:CommandIDs.voilaRender, category:'Notebook Operations'})
+    if (palette) {
+      palette.addItem({command:CommandIDs.voilaRender, category:'Notebook Operations'})
+    }
+
+    if (menu) {
+      menu.viewMenu.addGroup([
+        {
+          command: CommandIDs.voilaRender
+        }
+      ], 1000)
+    }
 
     let voilaButton = new VoilaRenderButton(app);
     app.docRegistry.addWidgetExtension('Notebook', voilaButton);
 
-    menu.viewMenu.addGroup([
-      {
-        command: CommandIDs.voilaRender
-      }
-    ], 1000)
     
   }
 };

--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -3,15 +3,17 @@ import {
 } from '@jupyterlab/application';
 
 import {
-  INotebookTracker, NotebookPanel
+  INotebookTracker, NotebookPanel, INotebookModel
 } from '@jupyterlab/notebook';
+
+import { IDocumentManager } from '@jupyterlab/docmanager';
 
 import {
   ReadonlyJSONObject
 } from '@phosphor/coreutils';
 
 import {
-    ICommandPalette,
+    ICommandPalette, MainAreaWidget, IFrame,
 } from '@jupyterlab/apputils';
 
 import {
@@ -22,8 +24,42 @@ import {
   PageConfig
 } from '@jupyterlab/coreutils';	
 
-import '../style/index.css';
+import {
+  ToolbarButton
+} from '@jupyterlab/apputils';
 
+import '../style/index.css';
+import { DocumentRegistry } from '@jupyterlab/docregistry';
+import { IDisposable } from '@phosphor/disposable';
+
+class VoilaRenderButton implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
+
+  constructor(app: JupyterLab) {
+    this.app = app;
+  }
+
+  readonly app: JupyterLab;
+
+  createNew(panel: NotebookPanel, context: DocumentRegistry.IContext<INotebookModel>): IDisposable {
+    let renderVoila = () => {
+      this.app.commands.execute('notebook:render-with-voila');
+    };
+
+    // Create the toolbar button
+    let button = new ToolbarButton({
+      className: 'voilaRender',
+      iconClassName: 'fa fa-desktop',
+      onClick: renderVoila,
+      label: 'Voila',
+      tooltip: 'Render with Voila'
+    });
+
+    panel.toolbar.insertItem(9, 'voilaRender', button);
+
+
+    return button;
+  }
+}
 
 /**
  * Initialization data for the jupyterlab-voila extension.
@@ -31,8 +67,8 @@ import '../style/index.css';
 const extension: JupyterLabPlugin<void> = {
   id: 'jupyterlab-voila',
   autoStart: true,
-  requires: [INotebookTracker, ICommandPalette, IMainMenu],
-  activate: (app: JupyterLab, notebooks: INotebookTracker, palette: ICommandPalette, menu: IMainMenu | null) => {
+  requires: [INotebookTracker, ICommandPalette, IMainMenu, IDocumentManager],
+  activate: (app: JupyterLab, notebooks: INotebookTracker, palette: ICommandPalette, menu: IMainMenu | null, docManager: IDocumentManager) => {
     console.log('JupyterLab extension jupyterlab-voila is activated!!!!!!!!');
 
     function getCurrent(args: ReadonlyJSONObject): NotebookPanel | null {
@@ -53,23 +89,45 @@ const extension: JupyterLabPlugin<void> = {
         );
     }
 
+    let counter = 0;
+
+    function voilaIFrame(url: string, text: string): MainAreaWidget {
+      let content = new IFrame();
+
+      content.url = url;
+      content.title.label = text;
+      content.id = `voila-${++counter}`;
+      let widget = new MainAreaWidget({ content });
+      return widget;
+    }
+
     app.commands.addCommand(CommandIDs.voilaRender, {
         label: 'Open/Render Notebook with Voila',
         execute: async (args) => {
           const current = getCurrent(args);
 
           if (current) {
-            const notebookPath = current.context.path;
-            const voilaPath = notebookPath.slice(0, notebookPath.length-6);  // without .ipynb
+            const voilaPath = current.context.path;
             const baseUrl = PageConfig.getBaseUrl();
             const voilaUrl = baseUrl + "voila/render/" + voilaPath;
-            window.open(voilaUrl)
+            // window.open(voilaUrl)
+
+            let widget = voilaIFrame(voilaUrl, "Voila");
+            app.shell.addToMainArea(widget, { mode: 'split-right'});
+            return widget;
+
+            // return app.commands.execute('docmanager:open', {
+            //   path: voilaUrl,
+            //   factory: 'HTML Viewer'
+            // });
           }
         },
         isEnabled
     });
     palette.addItem({command:CommandIDs.voilaRender, category:'Notebook Operations'})
 
+    let buttonExtension = new VoilaRenderButton(app);
+    app.docRegistry.addWidgetExtension('Notebook', buttonExtension);
 
     // TODO: what would be a good place to add it to the menu?
     // menu.fileMenu.addGroup(

--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -129,13 +129,11 @@ const extension: JupyterLabPlugin<void> = {
     let buttonExtension = new VoilaRenderButton(app);
     app.docRegistry.addWidgetExtension('Notebook', buttonExtension);
 
-    // TODO: what would be a good place to add it to the menu?
-    // menu.fileMenu.addGroup(
-    //     [
-    //       { command: CommandIDs.voilaRender },
-    //     ],
-    //     1000
-    // );
+    menu.viewMenu.addGroup([
+      {
+        command: CommandIDs.voilaRender
+      }
+    ], 1000)
     
   }
 };

--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -28,9 +28,11 @@ import {
   ToolbarButton
 } from '@jupyterlab/apputils';
 
-import '../style/index.css';
-import { DocumentRegistry } from '@jupyterlab/docregistry';
+import { DocumentRegistry } from "@jupyterlab/docregistry";
+
 import { IDisposable } from '@phosphor/disposable';
+
+import '../style/index.css';
 
 class VoilaRenderButton implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
 
@@ -45,7 +47,6 @@ class VoilaRenderButton implements DocumentRegistry.IWidgetExtension<NotebookPan
       this.app.commands.execute('notebook:render-with-voila');
     };
 
-    // Create the toolbar button
     let button = new ToolbarButton({
       className: 'voilaRender',
       iconClassName: 'fa fa-desktop',
@@ -55,7 +56,6 @@ class VoilaRenderButton implements DocumentRegistry.IWidgetExtension<NotebookPan
     });
 
     panel.toolbar.insertItem(9, 'voilaRender', button);
-
 
     return button;
   }
@@ -69,7 +69,6 @@ const extension: JupyterLabPlugin<void> = {
   autoStart: true,
   requires: [INotebookTracker, ICommandPalette, IMainMenu, IDocumentManager],
   activate: (app: JupyterLab, notebooks: INotebookTracker, palette: ICommandPalette, menu: IMainMenu | null, docManager: IDocumentManager) => {
-    console.log('JupyterLab extension jupyterlab-voila is activated!!!!!!!!');
 
     function getCurrent(args: ReadonlyJSONObject): NotebookPanel | null {
         const widget = notebooks.currentWidget;
@@ -102,7 +101,7 @@ const extension: JupyterLabPlugin<void> = {
     }
 
     app.commands.addCommand(CommandIDs.voilaRender, {
-        label: 'Open/Render Notebook with Voila',
+        label: 'Render Notebook with Voila',
         execute: async (args) => {
           const current = getCurrent(args);
 
@@ -110,24 +109,19 @@ const extension: JupyterLabPlugin<void> = {
             const voilaPath = current.context.path;
             const baseUrl = PageConfig.getBaseUrl();
             const voilaUrl = baseUrl + "voila/render/" + voilaPath;
-            // window.open(voilaUrl)
 
             let widget = voilaIFrame(voilaUrl, "Voila");
             app.shell.addToMainArea(widget, { mode: 'split-right'});
             return widget;
-
-            // return app.commands.execute('docmanager:open', {
-            //   path: voilaUrl,
-            //   factory: 'HTML Viewer'
-            // });
           }
         },
         isEnabled
     });
+
     palette.addItem({command:CommandIDs.voilaRender, category:'Notebook Operations'})
 
-    let buttonExtension = new VoilaRenderButton(app);
-    app.docRegistry.addWidgetExtension('Notebook', buttonExtension);
+    let voilaButton = new VoilaRenderButton(app);
+    app.docRegistry.addWidgetExtension('Notebook', voilaButton);
 
     menu.viewMenu.addGroup([
       {

--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -6,8 +6,6 @@ import {
   INotebookTracker, NotebookPanel, INotebookModel
 } from '@jupyterlab/notebook';
 
-import { IDocumentManager } from '@jupyterlab/docmanager';
-
 import {
   ReadonlyJSONObject
 } from '@phosphor/coreutils';
@@ -67,8 +65,8 @@ class VoilaRenderButton implements DocumentRegistry.IWidgetExtension<NotebookPan
 const extension: JupyterLabPlugin<void> = {
   id: 'jupyterlab-voila',
   autoStart: true,
-  requires: [INotebookTracker, ICommandPalette, IMainMenu, IDocumentManager],
-  activate: (app: JupyterLab, notebooks: INotebookTracker, palette: ICommandPalette, menu: IMainMenu | null, docManager: IDocumentManager) => {
+  requires: [INotebookTracker, ICommandPalette, IMainMenu],
+  activate: (app: JupyterLab, notebooks: INotebookTracker, palette: ICommandPalette, menu: IMainMenu | null) => {
 
     function getCurrent(args: ReadonlyJSONObject): NotebookPanel | null {
         const widget = notebooks.currentWidget;

--- a/packages/jupyterlab-voila/style/index.css
+++ b/packages/jupyterlab-voila/style/index.css
@@ -1,0 +1,3 @@
+.jp-VoilaIcon {
+  background-image: url('./voila.svg');
+}

--- a/packages/jupyterlab-voila/style/index.css
+++ b/packages/jupyterlab-voila/style/index.css
@@ -1,3 +1,3 @@
 .jp-VoilaIcon {
-  background-image: url('./voila.svg');
+  background-image: url("./voila.svg");
 }

--- a/packages/jupyterlab-voila/style/voila.svg
+++ b/packages/jupyterlab-voila/style/voila.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 5.8208336 5.8208336"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="voila.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="15.839192"
+     inkscape:cx="-12.866752"
+     inkscape:cy="4.350357"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:lockguides="true"
+     inkscape:window-width="2048"
+     inkscape:window-height="1115"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     units="px" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-80.641517,-138.91376)">
+    <g
+       aria-label="[voilà]"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:Manjari;-inkscape-font-specification:Manjari;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text817"
+       transform="matrix(0.16603774,0,0,0.16603774,69.679157,118.70141)" />
+    <g
+       aria-label="[v]"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.75723267px;line-height:1.25;font-family:Manjari;-inkscape-font-specification:Manjari;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.04393082"
+       id="text817-7">
+      <path
+         d="m 80.898924,139.42643 c -0.141574,0 -0.257407,0.11584 -0.257407,0.25741 l 0.0051,4.28068 c 0,0.14157 0.115833,0.25741 0.257407,0.25741 l 1.140313,0.003 h 0.0026 c 0.141573,0 0.257407,-0.11583 0.257407,-0.2574 0,-0.14158 -0.115834,-0.25741 -0.257407,-0.25741 h -0.0026 l -0.882906,-0.003 -0.0051,-3.76586 h 0.888054 c 0.141574,0 0.257408,-0.11584 0.257408,-0.25741 0,-0.14157 -0.115834,-0.25741 -0.257408,-0.25741 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:'Manjari Bold';fill:#f37726;fill-opacity:1;stroke-width:0.04393082"
+         id="path13" />
+      <path
+         d="m 82.34212,140.52814 c 0,0.0206 0.0051,0.0566 0.01544,0.0772 l 1.029629,2.33211 c 0.02574,0.0592 0.100388,0.10811 0.16474,0.10811 0.06435,0 0.139,-0.0489 0.164741,-0.10811 l 1.029628,-2.32439 c 0.0103,-0.0206 0.01802,-0.0541 0.01802,-0.0746 0,-0.10039 -0.0798,-0.18018 -0.180185,-0.18018 -0.06693,0 -0.141574,0.0515 -0.167315,0.11068 l -0.862314,1.95115 -0.867462,-1.96144 c -0.02574,-0.0618 -0.09781,-0.11069 -0.16474,-0.11069 -0.100389,0 -0.180185,0.0824 -0.180185,0.18019 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:Manjari;fill:#4e4e4e;fill-opacity:1;stroke-width:0.04393082"
+         id="path15" />
+      <path
+         d="m 86.204943,139.42386 h -1.145462 c -0.141574,0 -0.257407,0.11583 -0.257407,0.25741 0,0.14157 0.115833,0.2574 0.257407,0.2574 h 0.888055 l -0.0051,3.76587 -0.882907,0.003 h -0.0026 c -0.141574,0 -0.257407,0.11584 -0.257407,0.25741 0,0.14157 0.115833,0.25741 0.257407,0.25741 h 0.0026 l 1.140314,-0.003 c 0.141574,0 0.257407,-0.11583 0.257407,-0.2574 l 0.0051,-4.28068 c 0,-0.14158 -0.115833,-0.25741 -0.257407,-0.25741 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:'Manjari Bold';fill:#f37726;fill-opacity:1;stroke-width:0.04393082"
+         id="path17" />
+    </g>
+  </g>
+</svg>

--- a/packages/jupyterlab-voila/tsconfig.json
+++ b/packages/jupyterlab-voila/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "lib": ["es2015", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noUnusedLocals": true,
+    "outDir": "./lib",
+    "target": "es2015",
+    "strict": true,
+    "strictNullChecks": false,
+    "types": [],
+    "skipLibCheck": true
+  },
+  "include": ["src/*"]
+}


### PR DESCRIPTION
Fixes #39.

Replaces #40 (keeps Maarten's commit).

Add a JupyterLab extension to render a notebook with voila.

### TODO

- [x] Bootstrap the extension
- [x] Add a command to the command palette, view menu and notebook toolbar
- [x] Expose two commands: view in a JupyterLab panel (IFrame) and open in a new browser tab, using the server extension endpoint
- [x] Show the notebook name in the preview tab
- [x] Use `optional` instead of `requires` for dependencies
- [x] Use voila icon for the toolbar button and the preview title
- [x] Prettier git commit hook
- [ ] Render voila preview on save
- [ ] Handle current JupyterLab theme in the voila preview (dark / light)
- [ ] Add dev setup to CONTRIBUTING.md

![jupyterlab-extension](https://user-images.githubusercontent.com/591645/59288034-1f8d6a80-8c73-11e9-860f-c3449dd3dcb5.gif)

