### PR TITLE
Undefined name: from io import BytesIO for line 178

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools.command.develop import develop
 from setuptools.command.egg_info import egg_info
 from setuptools.command.bdist_egg import bdist_egg
 
+from io import BytesIO
 from subprocess import check_call
 
 import os


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/QuantStack/voila on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./setup.py:177:15: F821 undefined name 'BytesIO'
        buf = BytesIO()
              ^
1     F821 undefined name 'BytesIO'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
