### PR TITLE
Shut down kernels after running the tests

### DIFF
--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -41,6 +41,7 @@ def voila_app(voila_args, voila_config):
     voila_config(voila_app)
     voila_app.start()
     yield voila_app
+    voila_app.stop()
     voila_app.clear_instance()
 
 

--- a/voila/app.py
+++ b/voila/app.py
@@ -455,6 +455,10 @@ class Voila(Application):
             self.launch_browser()
         self.listen()
 
+    def stop(self):
+        shutil.rmtree(self.connection_dir)
+        self.kernel_manager.shutdown_all()
+
     def listen(self):
         self.app.listen(self.port)
         self.log.info('Voila is running at:\n%s' % self.display_url)
@@ -465,8 +469,7 @@ class Voila(Application):
         except KeyboardInterrupt:
             self.log.info('Stopping...')
         finally:
-            shutil.rmtree(self.connection_dir)
-            self.kernel_manager.shutdown_all()
+            self.stop()
 
     def launch_browser(self):
         try:


### PR DESCRIPTION
Fixes https://github.com/QuantStack/voila/issues/231.

Two changes:

- Add a `stop` method to `VoilaApp` to shut down the kernels
- Call that method when in the tests before clearing the `voila_app` instance

It's probably simple enough for now to fix the issue, but we might want to reconsider this approach later on especially regarding `pytest-tornado` (as pointed out by @martinRenou in #231)