### PR TITLE
Launch browser after listening

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -451,13 +451,14 @@ class Voila(Application):
             ])
 
         self.app.add_handlers('.*$', handlers)
-        if self.open_browser:
-            self.launch_browser()
         self.listen()
 
     def listen(self):
         self.app.listen(self.port)
         self.log.info('Voila is running at:\n%s' % self.display_url)
+
+        if self.open_browser:
+            self.launch_browser()
 
         self.ioloop = tornado.ioloop.IOLoop.current()
         try:


### PR DESCRIPTION
Launch the web browser only after the server is running (started to listen).

This prevents from opening a new tab when there is already an instance of voila running and another one is started afterwards using the same port (default for example).