### PR TITLE
Use pytest-tornado instead of pytest-tornado5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -285,7 +285,7 @@ setup_args = {
         'test': [
             'mock',
             'pytest<4',
-            'pytest-tornado5'
+            'pytest-tornado'
         ]
     },
     'author': 'QuantStack',


### PR DESCRIPTION
We should be good to go with `pytest-tornado` now.