### PR TITLE
Save the notebook before showing the Voila preview

### DIFF
--- a/packages/jupyterlab-voila/src/index.ts
+++ b/packages/jupyterlab-voila/src/index.ts
@@ -104,6 +104,7 @@ const extension: JupyterLabPlugin<void> = {
         if (!current) {
           return;
         }
+        await current.context.save();
         const voilaPath = current.context.path;
         const url = getVoilaUrl(voilaPath);
         const name = PathExt.basename(voilaPath);
@@ -121,6 +122,7 @@ const extension: JupyterLabPlugin<void> = {
         if (!current) {
           return;
         }
+        await current.context.save();
         const voilaUrl = getVoilaUrl(current.context.path);
         window.open(voilaUrl);
       },

--- a/voila/static/extension.js
+++ b/voila/static/extension.js
@@ -1,9 +1,10 @@
 define(['jquery', 'base/js/namespace'], function($, Jupyter) {
     "use strict";
     var open_voila = function() {
-        let voila_url = Jupyter.notebook.base_url + "voila/render/" + Jupyter.notebook.notebook_path;
-        window.open(voila_url)
-
+        Jupyter.notebook.save_notebook().then(function () {
+            let voila_url = Jupyter.notebook.base_url + "voila/render/" + Jupyter.notebook.notebook_path;
+            window.open(voila_url)
+        });
     }
     var load_ipython_extension = function() {
         Jupyter.toolbar.add_buttons_group([{


### PR DESCRIPTION
Fixes #257.

Automatically save the notebook before showing the voila preview.

## TODO

- [x] JupyterLab extension
- [x] Classic Notebook extension 

![jlab-save-render](https://user-images.githubusercontent.com/591645/59751200-6afdd500-9280-11e9-8dc3-cf460f12f2de.gif)

cc @wolfv 