### PR TITLE
Update author to Voila contributors

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -40,6 +40,6 @@
     "watch:lib": "babel src --out-dir lib --watch",
     "watch:bundle": "webpack --watch --mode=development"
   },
-  "author": "QuantStack",
+  "author": "Voila contributors",
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
To align with the license and the `author` for the JupyterLab extension.