### PR TITLE
updates the docs logo

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,7 @@ version = '.'.join(map(str, _release['version_info'][:2]))
 release = _release['__version__']
 language = None
 
-html_logo = 'quantstack-white.svg'
+html_logo = 'voila.svg'
 
 exclude_patterns = []
 highlight_language = 'python'


### PR DESCRIPTION
This updates the logo in the top-left of the RTD page. The logo was added to the index page, but it will disappear when people leave that page. Here's what it looks like:

![image](https://user-images.githubusercontent.com/1839645/59863067-da370000-9338-11e9-9e9b-727ec75b64e4.png)

Another option would be to add in a white background and make it a PNG, but this PR just deals w/ the SVG that's already there