### PR TITLE
Add server companion metadata

### DIFF
--- a/packages/jupyterlab-voila/package.json
+++ b/packages/jupyterlab-voila/package.json
@@ -60,6 +60,17 @@
     }
   },
   "jupyterlab": {
-    "extension": true
+    "extension": true,
+    "discovery": {
+      "server": {
+        "managers": [
+          "conda",
+          "pip"
+        ],
+        "base": {
+          "name": "voila"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #272.

Add metadata to the JLab extension that will show the following dialog when installed via the extension manager:

![image](https://user-images.githubusercontent.com/591645/60327777-0da70980-998d-11e9-9396-e0947f67161a.png)
