### PR TITLE
JLab extension post release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,13 +71,6 @@ Node.js is required and can be installed with conda:
 conda install -c conda-forge nodejs
 ```
 
-The extension is being developed for JupyterLab 1.0, which is going to be [released very soon](https://github.com/jupyterlab/jupyterlab/issues/6504). To install the alpha 1.0 release:
-
-```bash
-pip install --pre jupyterlab
-```
-
-
 To install the JupyterLab extension locally:
 
 ```bash

--- a/packages/jupyterlab-voila/README.md
+++ b/packages/jupyterlab-voila/README.md
@@ -1,0 +1,13 @@
+# @jupyter-voila/jupyterlab-preview
+
+A JupyterLab preview extension for Voila.
+
+## Prerequisites
+
+- JupyterLab 1.0
+
+## Install
+
+```bash
+jupyter labextension install @jupyter-voila/jupyterlab-preview
+```


### PR DESCRIPTION
- Remove mention to the JupyterLab alpha release in `CONTRIBUTING.md`
- Add basic `README.md` to it can render on the npm page