### PR TITLE
Add instructions to install dependencies of example notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ To render the `bqplot` example notebook as a standalone app, run
 `voila bqplot.ipynb`.
 To serve a directory of jupyter notebooks, run `voila` with no argument.
 
-For example, assuming you have already created and activated a
-[conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html),
-you want to run, specifically:
+For example, to render the example notebook `bqplot.ipynb` from this repository with voila, you can first update your current environment with the requirements of this notebook (in this case in a [conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) and render the notebook with
 
 ```
 conda env update -f environment.yml

--- a/README.md
+++ b/README.md
@@ -38,12 +38,18 @@ pip install voila
 ### As a standalone tornado application
 
 To render the `bqplot` example notebook as a standalone app, run
+`voila bqplot.ipynb`.
+To serve a directory of jupyter notebooks, run `voila` with no argument.
+
+For example, assuming you have already created and activated a
+[conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html),
+you want to run, specifically:
 
 ```
+conda env update -f environment.yml
+cd notebooks/
 voila bqplot.ipynb
 ```
-
-To serve a directory of jupyter notebooks, just run `voila` with no argument.
 
 For more command line options (e.g., to specify an alternate port number),
 run `voila --help`.
@@ -92,7 +98,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) to know how to contribute and setup a d
 
 ## Related projects
 
-Voila depends on the [nbconvert](https://github.com/jupyter/nbconvert) and
+Voila depends on [nbconvert](https://github.com/jupyter/nbconvert) and
 [jupyter_server](https://github.com/jupyter/jupyter_server/).
 
 ## License


### PR DESCRIPTION
Hello,

I made it clear that you need dependencies (as documented in `environment.yml`) to be able to run the demo notebooks (which live in `./notebooks/`).