### PR TITLE
Add pygments to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -279,7 +279,8 @@ setup_args = {
     'install_requires': [
         'jupyter_server>=0.0.5,<0.0.6',
         'nbconvert>=5.5.0,<6',
-        'jupyterlab_pygments>=0.1.0,<0.2'
+        'jupyterlab_pygments>=0.1.0,<0.2',
+        'pygments>=2.4.1,<3'
     ],
     'extras_require': {
         'test': [


### PR DESCRIPTION
Add an explicit requirement for the transitive `pygments` dependency (from [jupyterlab_pygment](https://github.com/jupyterlab/jupyterlab_pygments/blob/b6033176746b1b8405c2abe842f42d88b296fc1a/setup.py#L22)).

This error seems to occur quite frequently when installing voila via pip.

Related to #224, https://github.com/voila-gallery/gallery/issues/58, https://github.com/voila-gallery/gallery/issues/54.