### PR TITLE
Let exporter inherit from SlidesExporter to expose more resources

### DIFF
--- a/voila/exporter.py
+++ b/voila/exporter.py
@@ -14,7 +14,7 @@ from traitlets.config import Config
 from jinja2 import contextfilter
 
 from nbconvert.filters.markdown_mistune import IPythonRenderer, MarkdownWithMath
-from nbconvert.exporters.html import HTMLExporter
+from nbconvert.exporters.slides import SlidesExporter
 
 
 class VoilaMarkdownRenderer(IPythonRenderer):
@@ -30,8 +30,10 @@ class VoilaMarkdownRenderer(IPythonRenderer):
         return super(VoilaMarkdownRenderer, self).image(src, title, text)
 
 
-class VoilaExporter(HTMLExporter):
-    """Custom HTMLExporter that inlines the images using VoilaMarkdownRenderer"""
+class VoilaExporter(SlidesExporter):
+    """Custom SlidesExporter (which itself inherits from HTMLExporter) that
+    inlines the images using VoilaMarkdownRenderer.
+    """
 
     # The voila exporter overrides the markdown renderer from the HTMLExporter
     # to inline images.

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -67,6 +67,16 @@ class VoilaHandler(JupyterHandler):
             'theme': self.voila_configuration.theme
         }
 
+        # extra resources for reveal template
+        resources_reveal = {
+            'reveal': {
+                'theme': 'simple',
+                'transition': 'slide',
+                'scroll': 'False',
+            }
+        }
+        resources.update(resources_reveal)
+
         exporter = VoilaExporter(
             template_path=self.nbconvert_template_paths,
             config=self.exporter_config,


### PR DESCRIPTION
Hello,

With this change, we are paving the way for the reveal template. Without it, using the reveal template yields a 500 Internal Server Error.

Steps to reproduce:

* Copy directory `share/jupyter/voila/template/reveal` from https://github.com/QuantStack/voila/pull/54/files into `PREFIX/share/jupyter/voila/templates/`;
* Get `notebooks/rise_example.ipynb` from https://github.com/QuantStack/voila/pull/54/files and (from where the notebook lives) run
```
voila rise_example.ipynb --template=reveal
```

We now have
```py
ipdb> VoilaExporter.mro()                                                                                                                  
[<class 'voila.exporter.VoilaExporter'>, <class 'nbconvert.exporters.slides.SlidesExporter'>, <class 'nbconvert.exporters.html.HTMLExporter'>, <class 'nbconvert.exporters.templateexporter.TemplateExporter'>, <class 'nbconvert.exporters.exporter.Exporter'>, <class 'traitlets.config.configurable.LoggingConfigurable'>, <class 'traitlets.config.configurable.Configurable'>, <class 'traitlets.traitlets.HasTraits'>, <class 'traitlets.traitlets.HasDescriptors'>, <class 'object'>]
```
instead of
```py
ipdb> VoilaExporter.mro()                                                                                                                  
[<class 'voila.exporter.VoilaExporter'>, <class 'nbconvert.exporters.html.HTMLExporter'>, <class 'nbconvert.exporters.templateexporter.TemplateExporter'>, <class 'nbconvert.exporters.exporter.Exporter'>, <class 'traitlets.config.configurable.LoggingConfigurable'>, <class 'traitlets.config.configurable.Configurable'>, <class 'traitlets.traitlets.HasTraits'>, <class 'traitlets.traitlets.HasDescriptors'>, <class 'object'>]
```

/cc @maartenbreddels 