### PR TITLE
Passing custom resources to voila configuration

### DIFF
--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -20,7 +20,8 @@ class VoilaConfiguration(traitlets.config.Configurable):
             'template name to be used by voila.'
         )
     )
-    reveal_theme = Unicode('simple',
+    reveal_theme = Unicode(
+        'simple',
         allow_none=True,
         help="""
         Used only with template reveal, ignored otherwise.
@@ -31,7 +32,8 @@ class VoilaConfiguration(traitlets.config.Configurable):
         list of themes that ship by default with reveal.js.
         """
     ).tag(config=True)
-    reveal_transition = Unicode('slide',
+    reveal_transition = Unicode(
+        'slide',
         allow_none=True,
         help="""
         Used only with template reveal, ignored otherwise.
@@ -40,7 +42,8 @@ class VoilaConfiguration(traitlets.config.Configurable):
         none, fade, slide, convex, concave and zoom.
         """
     ).tag(config=True)
-    reveal_scroll = Bool(False,
+    reveal_scroll = Bool(
+        False,
         allow_none=True,
         help="""
         Used only with template reveal, ignored otherwise.

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -20,13 +20,12 @@ class VoilaConfiguration(traitlets.config.Configurable):
             'template name to be used by voila.'
         )
     )
-    extra_resources = Dict(
-        {},
+    resources = Dict(
         allow_none=True,
         help="""
         extra resources used by templates;
         example use with --template=reveal
-        --extra_resources="{'reveal': {'transition': 'fade', 'scroll': True}}"
+        --resources="{'reveal': {'transition': 'fade', 'scroll': True}}"
         """
     ).tag(config=True)
     theme = Unicode('light').tag(config=True)

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -7,7 +7,7 @@
 #############################################################################
 
 import traitlets.config
-from traitlets import Unicode, Bool
+from traitlets import Unicode, Bool, Dict
 
 
 class VoilaConfiguration(traitlets.config.Configurable):
@@ -20,34 +20,13 @@ class VoilaConfiguration(traitlets.config.Configurable):
             'template name to be used by voila.'
         )
     )
-    reveal_theme = Unicode(
-        'simple',
+    extra_resources = Dict(
+        {},
         allow_none=True,
         help="""
-        Used only with template reveal, ignored otherwise.
-        Name of the reveal.js theme to use.
-        We look for a file with this name under
-        ``reveal_url_prefix``/css/theme/``reveal_theme``.css.
-        https://github.com/hakimel/reveal.js/tree/master/css/theme has
-        list of themes that ship by default with reveal.js.
-        """
-    ).tag(config=True)
-    reveal_transition = Unicode(
-        'slide',
-        allow_none=True,
-        help="""
-        Used only with template reveal, ignored otherwise.
-        Name of the reveal.js transition to use.
-        The list of transitions that ships by default with reveal.js are:
-        none, fade, slide, convex, concave and zoom.
-        """
-    ).tag(config=True)
-    reveal_scroll = Bool(
-        False,
-        allow_none=True,
-        help="""
-        Used only with template reveal, ignored otherwise.
-        If True, enable scrolling within each slide
+        extra resources used by templates;
+        example use with --template=reveal
+        --extra_resources="{'reveal': {'transition': 'fade', 'scroll': True}}"
         """
     ).tag(config=True)
     theme = Unicode('light').tag(config=True)

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -20,6 +20,33 @@ class VoilaConfiguration(traitlets.config.Configurable):
             'template name to be used by voila.'
         )
     )
+    reveal_theme = Unicode('simple',
+        allow_none=True,
+        help="""
+        Used only with template reveal, ignored otherwise.
+        Name of the reveal.js theme to use.
+        We look for a file with this name under
+        ``reveal_url_prefix``/css/theme/``reveal_theme``.css.
+        https://github.com/hakimel/reveal.js/tree/master/css/theme has
+        list of themes that ship by default with reveal.js.
+        """
+    ).tag(config=True)
+    reveal_transition = Unicode('slide',
+        allow_none=True,
+        help="""
+        Used only with template reveal, ignored otherwise.
+        Name of the reveal.js transition to use.
+        The list of transitions that ships by default with reveal.js are:
+        none, fade, slide, convex, concave and zoom.
+        """
+    ).tag(config=True)
+    reveal_scroll = Bool(False,
+        allow_none=True,
+        help="""
+        Used only with template reveal, ignored otherwise.
+        If True, enable scrolling within each slide
+        """
+    ).tag(config=True)
     theme = Unicode('light').tag(config=True)
     strip_sources = Bool(True, help='Strip sources from rendered html').tag(config=True)
     enable_nbextensions = Bool(False, config=True, help=('Set to True for Voila to load notebook extensions'))

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -12,8 +12,6 @@ import tornado.web
 
 from jupyter_server.base.handlers import JupyterHandler
 
-from nbconvert.exporters.slides import prepare
-
 from .execute import executenb
 from .exporter import VoilaExporter
 
@@ -80,7 +78,7 @@ class VoilaHandler(JupyterHandler):
         resources.update(resources_reveal)
 
         # include potential extra resources
-        extra_resources = self.voila_configuration.extra_resources
+        extra_resources = self.voila_configuration.resources
         if extra_resources:
             for k in extra_resources.keys():
                 if k in resources.keys():
@@ -114,10 +112,6 @@ class VoilaHandler(JupyterHandler):
                 or not exporter.exclude_input                   # keep cell if input not excluded
             )
         result.cells = list(filter(filter_empty_code_cells, result.cells))
-
-        # add convenience metadata on cells for reveal template
-        if self.voila_configuration.template == 'reveal':
-            result = prepare(result)
 
         html, resources = exporter.from_notebook_node(result, resources=resources)
 

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -6,25 +6,15 @@
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
 
-import collections
 import os
 
 import tornado.web
 
 from jupyter_server.base.handlers import JupyterHandler
+from jupyter_server.config_manager import recursive_update
 
 from .execute import executenb
 from .exporter import VoilaExporter
-
-
-def update_nested_dict(d, u):
-    """Update (nested) dictionaries: update keys down to any depth."""
-    for k, v in u.items():
-        if isinstance(v, collections.Mapping):
-            d[k] = update_nested_dict(d.get(k, {}), v)
-        else:
-            d[k] = v
-    return d
 
 
 class VoilaHandler(JupyterHandler):
@@ -91,7 +81,7 @@ class VoilaHandler(JupyterHandler):
         # include potential extra resources
         extra_resources = self.voila_configuration.resources
         if extra_resources:
-            resources = update_nested_dict(resources, extra_resources)
+            recursive_update(resources, extra_resources)
 
         exporter = VoilaExporter(
             template_path=self.nbconvert_template_paths,

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -68,16 +68,6 @@ class VoilaHandler(JupyterHandler):
             'theme': self.voila_configuration.theme
         }
 
-        # add extra resources (necessary for reveal template)
-        resources_reveal = {
-            'reveal': {
-                'theme': 'simple',
-                'transition': 'slide',
-                'scroll': False,
-            }
-        }
-        resources.update(resources_reveal)
-
         # include potential extra resources
         extra_resources = self.voila_configuration.resources
         if extra_resources:

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -69,16 +69,15 @@ class VoilaHandler(JupyterHandler):
             'theme': self.voila_configuration.theme
         }
 
-        # add extra resources for reveal template
-        if self.voila_configuration.template == 'reveal':
-            resources_reveal = {
-                'reveal': {
-                    'theme': self.voila_configuration.reveal_theme,
-                    'transition': self.voila_configuration.reveal_transition,
-                    'scroll': self.voila_configuration.reveal_scroll,
-                }
+        # add extra resources (necessary for reveal template)
+        resources_reveal = {
+            'reveal': {
+                'theme': self.voila_configuration.reveal_theme,
+                'transition': self.voila_configuration.reveal_transition,
+                'scroll': self.voila_configuration.reveal_scroll,
             }
-            resources.update(resources_reveal)
+        }
+        resources.update(resources_reveal)
 
         exporter = VoilaExporter(
             template_path=self.nbconvert_template_paths,

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -72,12 +72,28 @@ class VoilaHandler(JupyterHandler):
         # add extra resources (necessary for reveal template)
         resources_reveal = {
             'reveal': {
-                'theme': self.voila_configuration.reveal_theme,
-                'transition': self.voila_configuration.reveal_transition,
-                'scroll': self.voila_configuration.reveal_scroll,
+                'theme': 'simple',
+                'transition': 'slide',
+                'scroll': False,
             }
         }
         resources.update(resources_reveal)
+
+        # include potential extra resources
+        extra_resources = self.voila_configuration.extra_resources
+        if extra_resources:
+            for k in extra_resources.keys():
+                if k in resources.keys():
+                    if isinstance(extra_resources[k], dict):
+                        for kk in extra_resources[k].keys():
+                            # update or add depth-2 resources
+                            resources[k][kk] = extra_resources[k][kk]
+                        else:
+                            # update depth-1 (top-level) resources
+                            resources[k] = extra_resources[k]
+                else:
+                    # add depth-1 (top-level) resources
+                    resources[k] = extra_resources[k]
 
         exporter = VoilaExporter(
             template_path=self.nbconvert_template_paths,

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -101,7 +101,8 @@ class VoilaHandler(JupyterHandler):
         result.cells = list(filter(filter_empty_code_cells, result.cells))
 
         # add convenience metadata on cells for reveal template
-        result = prepare(result)
+        if self.voila_configuration.template == 'reveal':
+            result = prepare(result)
 
         html, resources = exporter.from_notebook_node(result, resources=resources)
 


### PR DESCRIPTION
Hello,

This PR overwrites #298 (previously submitted). Example use:
```
voila reveal.ipynb --template=reveal --reveal_transition=fade
```
The config additions are almost copied-pasted from https://github.com/jupyter/nbconvert/blob/76061f8df164a742fc039b2574508bd8cf7d96a1/nbconvert/exporters/slides.py#L105-L130 -- should I add a comment about it?

/cc @maartenbreddels 