### PR TITLE
Monochrome voila icon for the notebook toolbar

### DIFF
--- a/packages/jupyterlab-voila/style/index.css
+++ b/packages/jupyterlab-voila/style/index.css
@@ -1,3 +1,5 @@
+@import "variables.css";
+
 .jp-VoilaIcon {
-  background-image: url("./voila.svg");
+  background-image: var(--jp-icon-voila);
 }

--- a/packages/jupyterlab-voila/style/variables.css
+++ b/packages/jupyterlab-voila/style/variables.css
@@ -1,0 +1,7 @@
+[data-jp-theme-light="true"] {
+  --jp-icon-voila: url("./voila-light.svg");
+}
+
+[data-jp-theme-light="false"] {
+  --jp-icon-voila: url("./voila-dark.svg");
+}

--- a/packages/jupyterlab-voila/style/voila-dark.svg
+++ b/packages/jupyterlab-voila/style/voila-dark.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 5.8208336 5.8208336"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="voila-dark.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="-1.9586888"
+     inkscape:cy="12.247911"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:lockguides="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1163"
+     inkscape:window-x="0"
+     inkscape:window-y="140"
+     inkscape:window-maximized="1"
+     units="px" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-80.641517,-138.91376)">
+    <g
+       aria-label="[voilà]"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:Manjari;-inkscape-font-specification:Manjari;letter-spacing:0px;word-spacing:0px;fill:#616161;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text817"
+       transform="matrix(0.16603774,0,0,0.16603774,69.679157,118.70141)"
+       inkscape:export-xdpi="99"
+       inkscape:export-ydpi="99" />
+    <g
+       aria-label="[v]"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.75723267px;line-height:1.25;font-family:Manjari;-inkscape-font-specification:Manjari;letter-spacing:0px;word-spacing:0px;fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:0.04393082"
+       id="text817-7"
+       inkscape:export-xdpi="99"
+       inkscape:export-ydpi="99">
+      <path
+         d="m 80.898924,139.42643 c -0.141574,0 -0.257407,0.11584 -0.257407,0.25741 l 0.0051,4.28068 c 0,0.14157 0.115833,0.25741 0.257407,0.25741 l 1.140313,0.003 h 0.0026 c 0.141573,0 0.257407,-0.11583 0.257407,-0.2574 0,-0.14158 -0.115834,-0.25741 -0.257407,-0.25741 h -0.0026 l -0.882906,-0.003 -0.0051,-3.76586 h 0.888054 c 0.141574,0 0.257408,-0.11584 0.257408,-0.25741 0,-0.14157 -0.115834,-0.25741 -0.257408,-0.25741 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:'Manjari Bold';fill:#e0e0e0;fill-opacity:1;stroke-width:0.04393082"
+         id="path13" />
+      <path
+         d="m 82.34212,140.52814 c 0,0.0206 0.0051,0.0566 0.01544,0.0772 l 1.029629,2.33211 c 0.02574,0.0592 0.100388,0.10811 0.16474,0.10811 0.06435,0 0.139,-0.0489 0.164741,-0.10811 l 1.029628,-2.32439 c 0.0103,-0.0206 0.01802,-0.0541 0.01802,-0.0746 0,-0.10039 -0.0798,-0.18018 -0.180185,-0.18018 -0.06693,0 -0.141574,0.0515 -0.167315,0.11068 l -0.862314,1.95115 -0.867462,-1.96144 c -0.02574,-0.0618 -0.09781,-0.11069 -0.16474,-0.11069 -0.100389,0 -0.180185,0.0824 -0.180185,0.18019 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:Manjari;fill:#e0e0e0;fill-opacity:1;stroke-width:0.04393082"
+         id="path15" />
+      <path
+         d="m 86.204943,139.42386 h -1.145462 c -0.141574,0 -0.257407,0.11583 -0.257407,0.25741 0,0.14157 0.115833,0.2574 0.257407,0.2574 h 0.888055 l -0.0051,3.76587 -0.882907,0.003 h -0.0026 c -0.141574,0 -0.257407,0.11584 -0.257407,0.25741 0,0.14157 0.115833,0.25741 0.257407,0.25741 h 0.0026 l 1.140314,-0.003 c 0.141574,0 0.257407,-0.11583 0.257407,-0.2574 l 0.0051,-4.28068 c 0,-0.14158 -0.115833,-0.25741 -0.257407,-0.25741 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:'Manjari Bold';fill:#e0e0e0;fill-opacity:1;stroke-width:0.04393082"
+         id="path17" />
+    </g>
+  </g>
+</svg>

--- a/packages/jupyterlab-voila/style/voila-light.svg
+++ b/packages/jupyterlab-voila/style/voila-light.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="22"
+   height="22"
+   viewBox="0 0 5.8208336 5.8208336"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="voila-light.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.4"
+     inkscape:cx="-1.9586888"
+     inkscape:cy="12.247911"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:lockguides="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1163"
+     inkscape:window-x="0"
+     inkscape:window-y="140"
+     inkscape:window-maximized="1"
+     units="px" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-80.641517,-138.91376)">
+    <g
+       aria-label="[voilà]"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:Manjari;-inkscape-font-specification:Manjari;letter-spacing:0px;word-spacing:0px;fill:#616161;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       id="text817"
+       transform="matrix(0.16603774,0,0,0.16603774,69.679157,118.70141)"
+       inkscape:export-xdpi="99"
+       inkscape:export-ydpi="99" />
+    <g
+       aria-label="[v]"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.75723267px;line-height:1.25;font-family:Manjari;-inkscape-font-specification:Manjari;letter-spacing:0px;word-spacing:0px;fill:#616161;fill-opacity:1;stroke:none;stroke-width:0.04393082"
+       id="text817-7"
+       inkscape:export-xdpi="99"
+       inkscape:export-ydpi="99">
+      <path
+         d="m 80.898924,139.42643 c -0.141574,0 -0.257407,0.11584 -0.257407,0.25741 l 0.0051,4.28068 c 0,0.14157 0.115833,0.25741 0.257407,0.25741 l 1.140313,0.003 h 0.0026 c 0.141573,0 0.257407,-0.11583 0.257407,-0.2574 0,-0.14158 -0.115834,-0.25741 -0.257407,-0.25741 h -0.0026 l -0.882906,-0.003 -0.0051,-3.76586 h 0.888054 c 0.141574,0 0.257408,-0.11584 0.257408,-0.25741 0,-0.14157 -0.115834,-0.25741 -0.257408,-0.25741 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:'Manjari Bold';fill:#616161;fill-opacity:1;stroke-width:0.04393082"
+         id="path13" />
+      <path
+         d="m 82.34212,140.52814 c 0,0.0206 0.0051,0.0566 0.01544,0.0772 l 1.029629,2.33211 c 0.02574,0.0592 0.100388,0.10811 0.16474,0.10811 0.06435,0 0.139,-0.0489 0.164741,-0.10811 l 1.029628,-2.32439 c 0.0103,-0.0206 0.01802,-0.0541 0.01802,-0.0746 0,-0.10039 -0.0798,-0.18018 -0.180185,-0.18018 -0.06693,0 -0.141574,0.0515 -0.167315,0.11068 l -0.862314,1.95115 -0.867462,-1.96144 c -0.02574,-0.0618 -0.09781,-0.11069 -0.16474,-0.11069 -0.100389,0 -0.180185,0.0824 -0.180185,0.18019 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:Manjari;fill:#616161;fill-opacity:1;stroke-width:0.04393082"
+         id="path15" />
+      <path
+         d="m 86.204943,139.42386 h -1.145462 c -0.141574,0 -0.257407,0.11583 -0.257407,0.25741 0,0.14157 0.115833,0.2574 0.257407,0.2574 h 0.888055 l -0.0051,3.76587 -0.882907,0.003 h -0.0026 c -0.141574,0 -0.257407,0.11584 -0.257407,0.25741 0,0.14157 0.115833,0.25741 0.257407,0.25741 h 0.0026 l 1.140314,-0.003 c 0.141574,0 0.257407,-0.11583 0.257407,-0.2574 l 0.0051,-4.28068 c 0,-0.14158 -0.115833,-0.25741 -0.257407,-0.25741 z"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:'Manjari Bold';fill:#616161;fill-opacity:1;stroke-width:0.04393082"
+         id="path17" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
The grey and orange default icon wouldn't render nice when using the Dark theme.

Switching to light and dark monochrome icons that follow the style of the existing Toolbar items.

![image](https://user-images.githubusercontent.com/591645/61203436-a9a17680-a6ea-11e9-9164-65fc2deb96e0.png)

![image](https://user-images.githubusercontent.com/591645/61203448-b1611b00-a6ea-11e9-80b1-c70acfab8f7d.png)
