### PR TITLE
feat: make the markdown rendered configurable in VoilaExporter

### DIFF
--- a/voila/exporter.py
+++ b/voila/exporter.py
@@ -33,16 +33,18 @@ class VoilaMarkdownRenderer(IPythonRenderer):
 class VoilaExporter(HTMLExporter):
     """Custom HTMLExporter that inlines the images using VoilaMarkdownRenderer"""
 
+    markdown_renderer_class = traitlets.Type('mistune.Renderer').tag(config=True)
+
     # The voila exporter overrides the markdown renderer from the HTMLExporter
     # to inline images.
-
     @contextfilter
     def markdown2html(self, context, source):
         cell = context['cell']
         attachments = cell.get('attachments', {})
-        renderer = VoilaMarkdownRenderer(escape=False, attachments=attachments,
-                                         contents_manager=self.contents_manager,
-                                         anchor_link_text=self.anchor_link_text)
+        cls = self.markdown_renderer_class
+        renderer = cls(escape=False, attachments=attachments,
+                       contents_manager=self.contents_manager,
+                       anchor_link_text=self.anchor_link_text)
         return MarkdownWithMath(renderer=renderer).render(source)
 
     # The voila exporter disables the CSSHTMLHeaderPreprocessor from the HTMLExporter.
@@ -53,6 +55,9 @@ class VoilaExporter(HTMLExporter):
             'CSSHTMLHeaderPreprocessor': {
                 'enabled': False
             },
+            'VoilaExporter': {
+                'markdown_renderer_class': 'voila.exporter.VoilaMarkdownRenderer'
+            }
         })
         c.merge(super(VoilaExporter, self).default_config)
         return c


### PR DESCRIPTION
Example configuration (e.g. in voila.json) could be:

```
'VoilaExporter': {
    'markdown_renderer_class': 'my.package.MyMarkdownRenderer'
}
```
Closes #234

We could argue that we want this to be in nbconvert, but we can have it in voila first, upstream it later without having compatibility issues.