### PR TITLE
Fix example use for config attribute resources

### DIFF
--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -25,7 +25,7 @@ class VoilaConfiguration(traitlets.config.Configurable):
         help="""
         extra resources used by templates;
         example use with --template=reveal
-        --resources="{'reveal': {'transition': 'fade', 'scroll': True}}"
+        --VoilaConfiguration.resources="{'reveal': {'transition': 'fade', 'scroll': True}}"
         """
     ).tag(config=True)
     theme = Unicode('light').tag(config=True)


### PR DESCRIPTION
Follows #301 (small fix).

The config attribute for passing custom resources isn't aliased (https://traitlets.readthedocs.io/en/stable/config.html#aliases).