### PR TITLE
Load (and use) template config from JSON file.

### DIFF
--- a/voila/app.py
+++ b/voila/app.py
@@ -32,12 +32,14 @@ import tornado.ioloop
 import tornado.web
 
 from traitlets.config.application import Application
+from traitlets.config.loader import JSONFileConfigLoader
 from traitlets import Unicode, Integer, Bool, Dict, List, default
 
 from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
 from jupyter_server.services.kernels.handlers import KernelHandler, ZMQChannelsHandler
 from jupyter_server.services.contents.largefilemanager import LargeFileManager
 from jupyter_server.base.handlers import path_regex
+from jupyter_server.config_manager import recursive_update
 from jupyter_server.utils import url_path_join
 from jupyter_server.services.config import ConfigManager
 from jupyter_server.base.handlers import FileFindHandler
@@ -339,6 +341,12 @@ class Voila(Application):
                 self.static_paths,
                 self.template_paths,
                 self.voila_configuration.template)
+            # then we load the template-related config
+            loader = JSONFileConfigLoader('conf.json', self.nbconvert_template_paths)
+            conf = loader.load_config()
+            # and update the overall config with it, preserving CLI config priority
+            recursive_update(dict(conf), dict(self.voila_configuration.config))
+            self.voila_configuration.config.VoilaConfiguration = conf.VoilaConfiguration
         self.log.debug('using template: %s', self.voila_configuration.template)
         self.log.debug('nbconvert template paths:\n\t%s', '\n\t'.join(self.nbconvert_template_paths))
         self.log.debug('template paths:\n\t%s', '\n\t'.join(self.template_paths))

--- a/voila/app.py
+++ b/voila/app.py
@@ -38,11 +38,10 @@ from traitlets import Unicode, Integer, Bool, Dict, List, default
 from jupyter_server.services.kernels.kernelmanager import MappingKernelManager
 from jupyter_server.services.kernels.handlers import KernelHandler, ZMQChannelsHandler
 from jupyter_server.services.contents.largefilemanager import LargeFileManager
-from jupyter_server.base.handlers import path_regex
+from jupyter_server.base.handlers import FileFindHandler, path_regex
 from jupyter_server.config_manager import recursive_update
 from jupyter_server.utils import url_path_join
 from jupyter_server.services.config import ConfigManager
-from jupyter_server.base.handlers import FileFindHandler
 
 from jupyter_core.paths import jupyter_config_path, jupyter_path
 
@@ -327,8 +326,6 @@ class Voila(Application):
 
         # then we load the config
         self.load_config_file('voila', path=self.config_file_paths)
-        # but that cli config has preference, so we overwrite with that
-        self.update_config(self.cli_config)
         # common configuration options between the server extension and the application
         self.voila_configuration = VoilaConfiguration(parent=self)
         self.setup_template_dirs()
@@ -451,12 +448,13 @@ class Voila(Application):
             handlers.extend([
                 (self.server_url, VoilaTreeHandler),
                 (url_path_join(self.server_url, r'/voila/tree' + path_regex), VoilaTreeHandler),
-                (url_path_join(self.server_url, r'/voila/render' + notebook_path_regex), VoilaHandler,
-                    {
-                        'nbconvert_template_paths': self.nbconvert_template_paths,
-                        'config': self.config,
-                        'voila_configuration': self.voila_configuration
-                    }),
+                (url_path_join(self.server_url, r'/voila/render' + notebook_path_regex),
+                 VoilaHandler,
+                 {
+                     'nbconvert_template_paths': self.nbconvert_template_paths,
+                     'config': self.config,
+                     'voila_configuration': self.voila_configuration
+                 }),
             ])
 
         self.app.add_handlers('.*$', handlers)

--- a/voila/app.py
+++ b/voila/app.py
@@ -340,10 +340,14 @@ class Voila(Application):
                 self.voila_configuration.template)
             # then we load the template-related config
             loader = JSONFileConfigLoader('conf.json', self.nbconvert_template_paths)
-            conf = loader.load_config()
-            # and update the overall config with it, preserving CLI config priority
-            recursive_update(dict(conf), dict(self.voila_configuration.config))
-            self.voila_configuration.config.VoilaConfiguration = conf.VoilaConfiguration
+            for path in self.nbconvert_template_paths:
+                conf = {}
+                conf_file = os.path.join(path, 'conf.json')
+                if os.path.exists(conf_file):
+                    conf = loader.load_config()
+                    # and update the overall config with it, preserving CLI config priority
+                    recursive_update(dict(conf), dict(self.voila_configuration.config))
+                    self.voila_configuration.config.VoilaConfiguration = conf.VoilaConfiguration
         self.log.debug('using template: %s', self.voila_configuration.template)
         self.log.debug('nbconvert template paths:\n\t%s', '\n\t'.join(self.nbconvert_template_paths))
         self.log.debug('template paths:\n\t%s', '\n\t'.join(self.template_paths))

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -69,7 +69,7 @@ class VoilaHandler(JupyterHandler):
         }
 
         # include potential extra resources
-        extra_resources = self.voila_configuration.resources
+        extra_resources = self.voila_configuration.config.VoilaConfiguration.resources
         if extra_resources:
             recursive_update(resources, extra_resources)
 

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -69,7 +69,7 @@ class VoilaHandler(JupyterHandler):
         }
 
         # include potential extra resources
-        extra_resources = self.voila_configuration.config.VoilaConfiguration.resources
+        extra_resources = self.voila_configuration.config.VoilaConfiguration.resources.to_dict()
         if extra_resources:
             recursive_update(resources, extra_resources)
 


### PR DESCRIPTION
Hello,

At the moment, `conf.json` files are detected in order to find all paths (populating, for instance, the `nbconvert_template_paths` attribute). But they are not actually loaded, let alone used.

As an aside, the reason for a945020 is `pylint` and https://github.com/ipython/traitlets/blob/7c6067ab10176d8cfd9039c4b96a04b725c31df6/traitlets/config/application.py#L773-L775, i.e., CLI config priority is already ensured within method `load_config_file()`.

With d17af8a, we load template-related `conf.json` files and merge them into the voila config (not the other way around, thus ensuring CLI config priority). Morally, I wanted to do parallel
https://github.com/QuantStack/voila/blob/08ea126952b8ce26c6903757ffcef7696d7f7a79/voila/app.py#L327
and do `self.load_config_file('conf', path=self.nbconvert_template_paths)` but I ran into the issue of `voila.configuration.VoilaConfiguration`'s methods not being recursive (for updating dict-like objects).

I have thus fallen back on using more generic `traitlets.config.loader.Config` objects (hence 4a5027c).

Example uses:
```
$ voila reveal.ipynb --template=reveal
$ voila reveal.ipynb --template=reveal --VoilaConfiguration.resources="{'reveal': {'transition': 'zoom'}}"
$ voila reveal.ipynb --template=reveal --VoilaConfiguration.resources="{'reveal': {'theme': 'simple', 'transition': 'zoom', 'scroll': True}}"
```
with upcoming https://github.com/QuantStack/voila-reveal :)

/cc @maartenbreddels 