### PR TITLE
Feat support py files via jupytext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server==0.1.0 jupyterlab_pygments==0.1.0 pytest==3.10.1 nbconvert=5.5 pytest-cov nodejs flake8 ipywidgets matplotlib
+  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server==0.1.0 jupyterlab_pygments==0.1.0 pytest==3.10.1 nbconvert=5.5 pytest-cov nodejs flake8 ipywidgets matplotlib jupytext
   - source activate test-environment
 install:
   - pip install ".[test]"

--- a/tests/notebooks/print.py
+++ b/tests/notebooks/print.py
@@ -1,0 +1,15 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.4'
+#       jupytext_version: 1.2.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python
+# ---
+
+print('Hi Voila!')

--- a/tests/server/execute_test.py
+++ b/tests/server/execute_test.py
@@ -3,10 +3,19 @@ import pytest
 
 
 @pytest.mark.gen_test
-def test_hello_world(http_client, print_notebook_url):
+def test_print(http_client, print_notebook_url):
     response = yield http_client.fetch(print_notebook_url)
     assert response.code == 200
     html_text = response.body.decode('utf-8')
     assert 'Hi Voila' in html_text
     assert 'print' not in html_text, 'by default the source code should be stripped'
     assert 'test_template.css' not in html_text, "test_template should not be the default"
+
+
+@pytest.mark.gen_test
+def test_print_py(http_client, print_notebook_url):
+    response = yield http_client.fetch(print_notebook_url.replace('ipynb', 'py'))
+    assert response.code == 200
+    html_text = response.body.decode('utf-8')
+    assert 'Hi Voila' in html_text
+    assert 'print' not in html_text, 'by default the source code should be stripped'

--- a/voila/paths.py
+++ b/voila/paths.py
@@ -16,7 +16,7 @@ STATIC_ROOT = os.path.join(ROOT, 'static')
 # if the directory above us contains the following paths, it means we are installed in dev mode (pip install -e .)
 DEV_MODE = os.path.exists(os.path.join(ROOT, '../setup.py')) and os.path.exists(os.path.join(ROOT, '../share'))
 
-notebook_path_regex = r'(.*\.ipynb)'
+notebook_path_regex = r'(.*\.(?:ipynb|py))'
 
 
 def collect_template_paths(


### PR DESCRIPTION
This partly solves #107 because jupytext works with jupyter server out of the box, so we can do:
```
$ jupytext --to py notebooks/basics.ipynb
$ jupyter server --ServerApp.token='' --ServerApp.open_browser=False
$ open http://localhost:8889/voila/render/notebooks/basics.py
```
And it just works.
For voila standalone support we just have to wait for #270 and get this for free.

If we don't want to wait for this we could add cmd line option to voila to force it to use jupytext, e.g.:
```
$ voila --VoilaApp.force_jupytext
```
Another option would be to support py files natively out of the box (I'll do a separate PR for that).

