### PR TITLE
Feat: support script files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server==0.1.0 jupyterlab_pygments==0.1.0 pytest==3.10.1 nbconvert=5.5 pytest-cov nodejs flake8 ipywidgets matplotlib
+  - conda create -q -n test-environment -c conda-forge python=$PYTHON_VERSION jupyter_server==0.1.0 jupyterlab_pygments==0.1.0 pytest==3.10.1 nbconvert=5.5 pytest-cov nodejs flake8 ipywidgets matplotlib xeus-cling
   - source activate test-environment
 install:
   - pip install ".[test]"
@@ -26,5 +26,5 @@ install:
 before_script:
   - flake8 voila tests setup.py
 script:
-  - VOILA_TEST_DEBUG=1 py.test tests/ --async-test-timeout=20
+  - VOILA_TEST_DEBUG=1 VOILA_TEST_XEUS_CLING=1 py.test tests/ --async-test-timeout=240
   - voila --help  # Making sure we can run `voila --help`

--- a/share/jupyter/voila/templates/default/templates/tree.html
+++ b/share/jupyter/voila/templates/default/templates/tree.html
@@ -80,7 +80,7 @@ data-server-root="{{server_root}}"
   {% endif %}
 
   {% for content in contents.content %}
-    {% if content.type == 'notebook' %}
+    {% if content.type in ['notebook', 'file'] %}
       <li><a href="{{base_url}}voila/render/{{content.path}}"><i class="fa fa-book"></i>{{content.name}}</a></li>
     {% endif %}
     {% if content.type == 'directory' %}

--- a/tests/app/execute_cpp_test.py
+++ b/tests/app/execute_cpp_test.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+
+TEST_XEUS_CLING = os.environ.get('VOILA_TEST_XEUS_CLING', '') == '1'
+
+
+@pytest.fixture
+def cpp_file_url(base_url):
+    return base_url + "/voila/render/print.xcpp"
+
+
+@pytest.fixture
+def voila_args_extra():
+    return ['--VoilaConfiguration.extension_language_mapping={".xcpp": "C++11"}']
+
+
+@pytest.fixture
+def voila_args(notebook_directory, voila_args_extra):
+    return ['--VoilaTest.root_dir=%r' % notebook_directory] + voila_args_extra
+
+
+@pytest.mark.skipif(not TEST_XEUS_CLING, reason='opt in to avoid having to install xeus-cling')
+@pytest.mark.gen_test
+def test_non_existing_kernel(http_client, cpp_file_url):
+    response = yield http_client.fetch(cpp_file_url)
+    assert response.code == 200
+    assert 'Hello voila, from c++' in response.body.decode('utf-8')

--- a/tests/app/serve_directory_test.py
+++ b/tests/app/serve_directory_test.py
@@ -1,5 +1,8 @@
-# test serving a notebook
+# test serving a notebook or python/c++ notebook
+import os
 import pytest
+
+TEST_XEUS_CLING = os.environ.get('VOILA_TEST_XEUS_CLING', '') == '1'
 
 
 @pytest.fixture
@@ -8,8 +11,30 @@ def voila_args(notebook_directory, voila_args_extra):
 
 
 @pytest.mark.gen_test
-def test_hello_world(http_client, print_notebook_url):
+def test_print(http_client, print_notebook_url):
     print(print_notebook_url)
     response = yield http_client.fetch(print_notebook_url)
     assert response.code == 200
     assert 'Hi Voila' in response.body.decode('utf-8')
+
+
+@pytest.fixture
+def voila_args_extra():
+    return ['--VoilaConfiguration.extension_language_mapping={".py": "python"}']
+
+
+@pytest.mark.gen_test
+def test_print_py(http_client, print_notebook_url):
+    print(print_notebook_url)
+    response = yield http_client.fetch(print_notebook_url.replace('ipynb', 'py'))
+    assert response.code == 200
+    assert 'Hi Voila' in response.body.decode('utf-8')
+
+
+@pytest.mark.skipif(not TEST_XEUS_CLING, reason='opt in to avoid having to install xeus-cling')
+@pytest.mark.gen_test
+def test_print_julia_notebook(http_client, print_notebook_url):
+    print(print_notebook_url)
+    response = yield http_client.fetch(print_notebook_url.replace('.ipynb', '_cpp.ipynb'))
+    assert response.code == 200
+    assert 'Hi Voila, from c++' in response.body.decode('utf-8')

--- a/tests/app/tree_test.py
+++ b/tests/app/tree_test.py
@@ -19,4 +19,4 @@ def test_tree(http_client, base_url):
     text = response.body.decode('utf-8')
     assert 'print.ipynb' in text, 'tree handler should render ipynb files'
     assert 'print.xcpp' in text, 'tree handler should render xcpp files (due to extension_language_mapping)'
-    assert 'print.py' not in text, 'treeh handler should not render .py files (due to extension_language_mapping)'
+    assert 'print.py' not in text, 'tree handler should not render .py files (due to extension_language_mapping)'

--- a/tests/app/tree_test.py
+++ b/tests/app/tree_test.py
@@ -1,0 +1,22 @@
+# test tree rendering
+import pytest
+
+
+@pytest.fixture
+def voila_args(notebook_directory, voila_args_extra):
+    return ['--VoilaTest.root_dir=%r' % notebook_directory, '--VoilaTest.log_level=DEBUG'] + voila_args_extra
+
+
+@pytest.fixture
+def voila_args_extra():
+    return ['--VoilaConfiguration.extension_language_mapping={".xcpp": "C++11"}']
+
+
+@pytest.mark.gen_test
+def test_tree(http_client, base_url):
+    response = yield http_client.fetch(base_url)
+    assert response.code == 200
+    text = response.body.decode('utf-8')
+    assert 'print.ipynb' in text, 'tree handler should render ipynb files'
+    assert 'print.xcpp' in text, 'tree handler should render xcpp files (due to extension_language_mapping)'
+    assert 'print.py' not in text, 'treeh handler should not render .py files (due to extension_language_mapping)'

--- a/tests/notebooks/print.py
+++ b/tests/notebooks/print.py
@@ -1,0 +1,15 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.4'
+#       jupytext_version: 1.2.1
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python
+# ---
+
+print('Hi Voila!')

--- a/tests/notebooks/print.xcpp
+++ b/tests/notebooks/print.xcpp
@@ -1,0 +1,23 @@
+// ---
+// jupyter:
+//   jupytext:
+//     text_representation:
+//       extension: .cpp
+//       format_name: light
+//       format_version: '1.4'
+//       jupytext_version: 1.2.1
+//   kernelspec:
+//     display_name: C++11
+//     language: C++11
+//     name: xcpp11
+// ---
+
+
+// this is not a valid .cpp file, since it does not have a main()
+// however, we can ask voila to execute this by using the xeus-cling kernel
+// or relying on jupytext
+
+#include <iostream>
+using namespace std;
+
+cout << "Hello voila, from c++";

--- a/tests/notebooks/print_cpp.ipynb
+++ b/tests/notebooks/print_cpp.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#include <iostream>\n",
+    "using namespace std;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cout << \"Hi Voila, from c++\";"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "C++11",
+   "language": "C++11",
+   "name": "xcpp11"
+  },
+  "language_info": {
+   "codemirror_mode": "text/x-c++src",
+   "file_extension": ".cpp",
+   "mimetype": "text/x-c++src",
+   "name": "c++",
+   "version": "-std=c++11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/server/execute_cpp_test.py
+++ b/tests/server/execute_cpp_test.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+
+TEST_XEUS_CLING = os.environ.get('VOILA_TEST_XEUS_CLING', '') == '1'
+
+
+@pytest.fixture
+def cpp_file_url(base_url):
+    return base_url + "/voila/render/print.xcpp"
+
+
+@pytest.fixture
+def jupyter_server_args_extra():
+    return ['--VoilaConfiguration.extension_language_mapping={".xcpp": "C++11"}']
+
+
+@pytest.fixture
+def voila_args(notebook_directory, voila_args_extra):
+    return ['--VoilaTest.root_dir=%r' % notebook_directory] + voila_args_extra
+
+
+@pytest.mark.skipif(not TEST_XEUS_CLING, reason='opt in to avoid having to install xeus-cling')
+@pytest.mark.gen_test
+def test_non_existing_kernel(http_client, cpp_file_url):
+    response = yield http_client.fetch(cpp_file_url)
+    assert response.code == 200
+    assert 'Hello voila, from c++' in response.body.decode('utf-8')

--- a/tests/server/tree_test.py
+++ b/tests/server/tree_test.py
@@ -1,0 +1,22 @@
+# test tree rendering
+import pytest
+
+
+@pytest.fixture
+def voila_args(notebook_directory, voila_args_extra):
+    return ['--VoilaTest.root_dir=%r' % notebook_directory, '--VoilaTest.log_level=DEBUG'] + voila_args_extra
+
+
+@pytest.fixture
+def jupyter_server_args_extra():
+    return ['--VoilaConfiguration.extension_language_mapping={".xcpp": "C++11"}']
+
+
+@pytest.mark.gen_test
+def test_tree(http_client, base_url):
+    response = yield http_client.fetch(base_url+'/voila/tree')
+    assert response.code == 200
+    text = response.body.decode('utf-8')
+    assert 'print.ipynb' in text, 'tree handler should render ipynb files'
+    assert 'print.xcpp' in text, 'tree handler should render xcpp files (due to extension_language_mapping)'
+    assert 'print.py' not in text, 'tree handler should not render .py files (due to extension_language_mapping)'

--- a/voila/app.py
+++ b/voila/app.py
@@ -453,6 +453,9 @@ class Voila(Application):
             )
         )
 
+        tree_handler_conf = {
+            'voila_configuration': self.voila_configuration
+        }
         if self.notebook_path:
             handlers.append((
                 url_path_join(self.server_url, r'/(.*)'),
@@ -467,8 +470,8 @@ class Voila(Application):
         else:
             self.log.debug('serving directory: %r', self.root_dir)
             handlers.extend([
-                (self.server_url, VoilaTreeHandler),
-                (url_path_join(self.server_url, r'/voila/tree' + path_regex), VoilaTreeHandler),
+                (self.server_url, VoilaTreeHandler, tree_handler_conf),
+                (url_path_join(self.server_url, r'/voila/tree' + path_regex), VoilaTreeHandler, tree_handler_conf),
                 (url_path_join(self.server_url, r'/voila/render/(.*)'), VoilaHandler,
                     {
                         'nbconvert_template_paths': self.nbconvert_template_paths,

--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -51,5 +51,21 @@ class VoilaConfiguration(traitlets.config.Configurable):
     Example:
     --VoilaConfiguration.file_whitelist="['.*']" # all files
     --VoilaConfiguration.file_blacklist="['private.*', '.*\.(ipynb)']" # except files in the private dir and notebook files
-    """,
+    """
+    ).tag(config=True)
+
+    language_kernel_mapping = Dict(
+        {},
+        help="""Mapping of language name to kernel name
+        Example mapping python to use xeus-python, and C++11 to use xeus-cling:
+        --VoilaConfiguration.extension_language_mapping='{"python": "xpython", "C++11": "xcpp11"}'
+        """,
+    ).tag(config=True)
+
+    extension_language_mapping = Dict(
+        {},
+        help='''Mapping of file extension to kernel language
+        Example mapping .py files to a python language kernel, and .cpp to a C++11 language kernel:
+        --VoilaConfiguration.extension_language_mapping='{".py": "python", ".cpp": "C++11"}'
+        ''',
     ).tag(config=True)

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -48,14 +48,17 @@ def load_jupyter_server_extension(server_app):
     host_pattern = '.*$'
     base_url = url_path_join(web_app.settings['base_url'])
 
+    tree_handler_conf = {
+        'voila_configuration': voila_configuration
+    }
     web_app.add_handlers(host_pattern, [
         (url_path_join(base_url, '/voila/render/(.*)'), VoilaHandler, {
             'config': server_app.config,
             'nbconvert_template_paths': nbconvert_template_paths,
             'voila_configuration': voila_configuration
         }),
-        (url_path_join(base_url, '/voila'), VoilaTreeHandler),
-        (url_path_join(base_url, '/voila/tree' + path_regex), VoilaTreeHandler),
+        (url_path_join(base_url, '/voila'), VoilaTreeHandler, tree_handler_conf),
+        (url_path_join(base_url, '/voila/tree' + path_regex), VoilaTreeHandler, tree_handler_conf),
         (url_path_join(base_url, '/voila/static/(.*)'), MultiStaticFileHandler, {'paths': static_paths}),
         (
             url_path_join(base_url, r'/voila/files/(.*)'),


### PR DESCRIPTION
Depends on #309  (alternative to #328)

Now we can do:
```
$ voila tests/notebooks/print.jl
$ voila tests/notebooks/print.py
```

It works by injecting the script code into an in-memory single-cell notebook, which means the last expression is printed out. If for some reasons one needs more output, you can use `display(expression)`, or use jupytext (which should also be supported with this PR).

