### PR TITLE
feat: serve static files similar to the notebook

### DIFF
--- a/voila/configuration.py
+++ b/voila/configuration.py
@@ -7,7 +7,7 @@
 #############################################################################
 
 import traitlets.config
-from traitlets import Unicode, Bool, Dict
+from traitlets import Unicode, Bool, Dict, List
 
 
 class VoilaConfiguration(traitlets.config.Configurable):
@@ -31,3 +31,25 @@ class VoilaConfiguration(traitlets.config.Configurable):
     theme = Unicode('light').tag(config=True)
     strip_sources = Bool(True, help='Strip sources from rendered html').tag(config=True)
     enable_nbextensions = Bool(False, config=True, help=('Set to True for Voila to load notebook extensions'))
+
+    file_whitelist = List(
+        Unicode(),
+        [r'.*\.(png|jpg|gif|svg)'],
+        help=r"""
+    List of regular expressions for controlling which static files are served.
+    All files that are served should at least match 1 whitelist rule, and no blacklist rule
+    Example: --VoilaConfiguration.file_whitelist="['.*\.(png|jpg|gif|svg)', 'public.*']"
+    """,
+    ).tag(config=True)
+
+    file_blacklist = List(
+        Unicode(),
+        [r'.*\.(ipynb|py)'],
+        help=r"""
+    List of regular expressions for controlling which static files are forbidden to be served.
+    All files that are served should at least match 1 whitelist rule, and no blacklist rule
+    Example:
+    --VoilaConfiguration.file_whitelist="['.*']" # all files
+    --VoilaConfiguration.file_blacklist="['private.*', '.*\.(ipynb)']" # except files in the private dir and notebook files
+    """,
+    ).tag(config=True)

--- a/voila/paths.py
+++ b/voila/paths.py
@@ -16,8 +16,6 @@ STATIC_ROOT = os.path.join(ROOT, 'static')
 # if the directory above us contains the following paths, it means we are installed in dev mode (pip install -e .)
 DEV_MODE = os.path.exists(os.path.join(ROOT, '../setup.py')) and os.path.exists(os.path.join(ROOT, '../share'))
 
-notebook_path_regex = r'(.*\.ipynb)'
-
 
 def collect_template_paths(
         nbconvert_template_paths,

--- a/voila/server_extension.py
+++ b/voila/server_extension.py
@@ -15,10 +15,10 @@ from jupyter_server.utils import url_path_join
 from jupyter_server.base.handlers import path_regex
 from jupyter_server.base.handlers import FileFindHandler
 
-from .paths import ROOT, STATIC_ROOT, collect_template_paths, jupyter_path, notebook_path_regex
+from .paths import ROOT, STATIC_ROOT, collect_template_paths, jupyter_path
 from .handler import VoilaHandler
 from .treehandler import VoilaTreeHandler
-from .static_file_handler import MultiStaticFileHandler
+from .static_file_handler import MultiStaticFileHandler, WhiteListFileHandler
 from .configuration import VoilaConfiguration
 
 
@@ -49,7 +49,7 @@ def load_jupyter_server_extension(server_app):
     base_url = url_path_join(web_app.settings['base_url'])
 
     web_app.add_handlers(host_pattern, [
-        (url_path_join(base_url, '/voila/render' + notebook_path_regex), VoilaHandler, {
+        (url_path_join(base_url, '/voila/render/(.*)'), VoilaHandler, {
             'config': server_app.config,
             'nbconvert_template_paths': nbconvert_template_paths,
             'voila_configuration': voila_configuration
@@ -57,6 +57,15 @@ def load_jupyter_server_extension(server_app):
         (url_path_join(base_url, '/voila'), VoilaTreeHandler),
         (url_path_join(base_url, '/voila/tree' + path_regex), VoilaTreeHandler),
         (url_path_join(base_url, '/voila/static/(.*)'), MultiStaticFileHandler, {'paths': static_paths}),
+        (
+            url_path_join(base_url, r'/voila/files/(.*)'),
+            WhiteListFileHandler,
+            {
+                'whitelist': voila_configuration.file_whitelist,
+                'blacklist': voila_configuration.file_blacklist,
+                'path': os.path.expanduser(web_app.settings['server_root_dir']),
+            },
+        ),
     ])
 
     # Serving notebook extensions

--- a/voila/static_file_handler.py
+++ b/voila/static_file_handler.py
@@ -7,6 +7,7 @@
 #############################################################################
 
 import os
+import re
 
 import tornado.web
 
@@ -37,3 +38,21 @@ class MultiStaticFileHandler(tornado.web.StaticFileHandler):
                 self.root = root  # make sure all the other methods in the base class know how to find the file
                 break
         return abspath
+
+
+class WhiteListFileHandler(tornado.web.StaticFileHandler):
+    def initialize(self, whitelist=[], blacklist=[], **kwargs):
+        self.whitelist = whitelist
+        self.blacklist = blacklist
+        super(WhiteListFileHandler, self).initialize(**kwargs)
+
+    def get_absolute_path(self, root, path):
+        # StaticFileHandler.get always calls this method first, so we use this as the
+        # place to check the path. Note that now the path seperator is os dependent (\\ on windows)
+        whitelisted = any(re.fullmatch(pattern, path) for pattern in self.whitelist)
+        blacklisted = any(re.fullmatch(pattern, path) for pattern in self.blacklist)
+        if not whitelisted:
+            raise tornado.web.HTTPError(403, 'File not whitelisted')
+        if blacklisted:
+            raise tornado.web.HTTPError(403, 'File blacklisted')
+        return super(WhiteListFileHandler, self).get_absolute_path(root, path)


### PR DESCRIPTION
but limited by whitelist and blacklist rules.

# Issue

When using the following in a Jupyter notebook:
```python
import ipywidgets
html = ipywidgets.HTML(value='<img src="./quantstack.svg"></img>')
html
```
The Jupyter notebook server will happily serve the svg file.

However, in voila, we consider this a security risk, since we do not assume the users are trusted (we don't want to give users access to our files). However, in voila, we'd like this to work as well.

# Solution 
This PR solves this by having whitelist and blacklist regexes that protect the content that is served. Each request for a file needs to match *at least one whitelist regex and NO blacklist regex* 

E.g. to serve all files, except those starting with private, or notebook files:
```
voila mynotebook.ipynb --VoilaConfiguration.file_whitelist="['.*']" --VoilaConfiguration.file_blacklist="['private.*', '.*\.(ipynb)']"
```

To serve only images:
```
voila tests/ --VoilaConfiguration.file_whitelist=ile_whitelist="['.*\.(png|jpg|gif|svg)']"
```

# Uncertain
I think that we should not always redirect in the handler.py, since it tells users that a file exists (this gives an attacker information which files exists). I think we should check the rules in two places.

Should the default be as it is now (images, and notebooks/py files always blacklisted)?


TODO:
 * [ ] tests
 * [ ] docs