### PR TITLE
Optimize svg icons, fix JLab 1.1 issue

### DIFF
--- a/packages/jupyterlab-voila/style/voila-dark.svg
+++ b/packages/jupyterlab-voila/style/voila-dark.svg
@@ -1,89 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="22"
-   height="22"
-   viewBox="0 0 5.8208336 5.8208336"
-   version="1.1"
-   id="svg8"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
-   sodipodi:docname="voila-dark.svg">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="22.4"
-     inkscape:cx="-1.9586888"
-     inkscape:cy="12.247911"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     inkscape:lockguides="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1163"
-     inkscape:window-x="0"
-     inkscape:window-y="140"
-     inkscape:window-maximized="1"
-     units="px" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(-80.641517,-138.91376)">
-    <g
-       aria-label="[voilà]"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:Manjari;-inkscape-font-specification:Manjari;letter-spacing:0px;word-spacing:0px;fill:#616161;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text817"
-       transform="matrix(0.16603774,0,0,0.16603774,69.679157,118.70141)"
-       inkscape:export-xdpi="99"
-       inkscape:export-ydpi="99" />
-    <g
-       aria-label="[v]"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.75723267px;line-height:1.25;font-family:Manjari;-inkscape-font-specification:Manjari;letter-spacing:0px;word-spacing:0px;fill:#e0e0e0;fill-opacity:1;stroke:none;stroke-width:0.04393082"
-       id="text817-7"
-       inkscape:export-xdpi="99"
-       inkscape:export-ydpi="99">
-      <path
-         d="m 80.898924,139.42643 c -0.141574,0 -0.257407,0.11584 -0.257407,0.25741 l 0.0051,4.28068 c 0,0.14157 0.115833,0.25741 0.257407,0.25741 l 1.140313,0.003 h 0.0026 c 0.141573,0 0.257407,-0.11583 0.257407,-0.2574 0,-0.14158 -0.115834,-0.25741 -0.257407,-0.25741 h -0.0026 l -0.882906,-0.003 -0.0051,-3.76586 h 0.888054 c 0.141574,0 0.257408,-0.11584 0.257408,-0.25741 0,-0.14157 -0.115834,-0.25741 -0.257408,-0.25741 z"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:'Manjari Bold';fill:#e0e0e0;fill-opacity:1;stroke-width:0.04393082"
-         id="path13" />
-      <path
-         d="m 82.34212,140.52814 c 0,0.0206 0.0051,0.0566 0.01544,0.0772 l 1.029629,2.33211 c 0.02574,0.0592 0.100388,0.10811 0.16474,0.10811 0.06435,0 0.139,-0.0489 0.164741,-0.10811 l 1.029628,-2.32439 c 0.0103,-0.0206 0.01802,-0.0541 0.01802,-0.0746 0,-0.10039 -0.0798,-0.18018 -0.180185,-0.18018 -0.06693,0 -0.141574,0.0515 -0.167315,0.11068 l -0.862314,1.95115 -0.867462,-1.96144 c -0.02574,-0.0618 -0.09781,-0.11069 -0.16474,-0.11069 -0.100389,0 -0.180185,0.0824 -0.180185,0.18019 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:Manjari;fill:#e0e0e0;fill-opacity:1;stroke-width:0.04393082"
-         id="path15" />
-      <path
-         d="m 86.204943,139.42386 h -1.145462 c -0.141574,0 -0.257407,0.11583 -0.257407,0.25741 0,0.14157 0.115833,0.2574 0.257407,0.2574 h 0.888055 l -0.0051,3.76587 -0.882907,0.003 h -0.0026 c -0.141574,0 -0.257407,0.11584 -0.257407,0.25741 0,0.14157 0.115833,0.25741 0.257407,0.25741 h 0.0026 l 1.140314,-0.003 c 0.141574,0 0.257407,-0.11583 0.257407,-0.2574 l 0.0051,-4.28068 c 0,-0.14158 -0.115833,-0.25741 -0.257407,-0.25741 z"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:'Manjari Bold';fill:#e0e0e0;fill-opacity:1;stroke-width:0.04393082"
-         id="path17" />
-    </g>
+<svg width="16" height="16" version="1.1" viewBox="0 0 5.8208 5.8208" xmlns="http://www.w3.org/2000/svg">
+ <g transform="translate(-80.642 -138.91)">
+  <g fill="#e0e0e0" stroke-width=".043931" aria-label="[v]">
+   <path d="m80.899 139.43c-0.14157 0-0.25741 0.11584-0.25741 0.25741l0.0051 4.2807c0 0.14157 0.11583 0.25741 0.25741 0.25741l1.1403 3e-3h0.0026c0.14157 0 0.25741-0.11583 0.25741-0.2574 0-0.14158-0.11583-0.25741-0.25741-0.25741h-0.0026l-0.88291-3e-3 -0.0051-3.7659h0.88805c0.14157 0 0.25741-0.11584 0.25741-0.25741s-0.11583-0.25741-0.25741-0.25741z"/>
+   <path d="m82.342 140.53c0 0.0206 0.0051 0.0566 0.01544 0.0772l1.0296 2.3321c0.02574 0.0592 0.10039 0.10811 0.16474 0.10811 0.06435 0 0.139-0.0489 0.16474-0.10811l1.0296-2.3244c0.0103-0.0206 0.01802-0.0541 0.01802-0.0746 0-0.10039-0.0798-0.18018-0.18018-0.18018-0.06693 0-0.14157 0.0515-0.16732 0.11068l-0.86231 1.9512-0.86746-1.9614c-0.02574-0.0618-0.09781-0.11069-0.16474-0.11069-0.10039 0-0.18018 0.0824-0.18018 0.18019z"/>
+   <path d="m86.205 139.42h-1.1455c-0.14157 0-0.25741 0.11583-0.25741 0.25741 0 0.14157 0.11583 0.2574 0.25741 0.2574h0.88806l-0.0051 3.7659-0.88291 3e-3h-0.0026c-0.14157 0-0.25741 0.11584-0.25741 0.25741s0.11583 0.25741 0.25741 0.25741h0.0026l1.1403-3e-3c0.14157 0 0.25741-0.11583 0.25741-0.2574l0.0051-4.2807c0-0.14158-0.11583-0.25741-0.25741-0.25741z"/>
   </g>
+ </g>
 </svg>

--- a/packages/jupyterlab-voila/style/voila-light.svg
+++ b/packages/jupyterlab-voila/style/voila-light.svg
@@ -1,89 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="22"
-   height="22"
-   viewBox="0 0 5.8208336 5.8208336"
-   version="1.1"
-   id="svg8"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
-   sodipodi:docname="voila-light.svg">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="22.4"
-     inkscape:cx="-1.9586888"
-     inkscape:cy="12.247911"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="false"
-     fit-margin-top="0"
-     fit-margin-left="0"
-     fit-margin-right="0"
-     fit-margin-bottom="0"
-     inkscape:lockguides="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1163"
-     inkscape:window-x="0"
-     inkscape:window-y="140"
-     inkscape:window-maximized="1"
-     units="px" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(-80.641517,-138.91376)">
-    <g
-       aria-label="[voilà]"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.58333302px;line-height:1.25;font-family:Manjari;-inkscape-font-specification:Manjari;letter-spacing:0px;word-spacing:0px;fill:#616161;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       id="text817"
-       transform="matrix(0.16603774,0,0,0.16603774,69.679157,118.70141)"
-       inkscape:export-xdpi="99"
-       inkscape:export-ydpi="99" />
-    <g
-       aria-label="[v]"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:1.75723267px;line-height:1.25;font-family:Manjari;-inkscape-font-specification:Manjari;letter-spacing:0px;word-spacing:0px;fill:#616161;fill-opacity:1;stroke:none;stroke-width:0.04393082"
-       id="text817-7"
-       inkscape:export-xdpi="99"
-       inkscape:export-ydpi="99">
-      <path
-         d="m 80.898924,139.42643 c -0.141574,0 -0.257407,0.11584 -0.257407,0.25741 l 0.0051,4.28068 c 0,0.14157 0.115833,0.25741 0.257407,0.25741 l 1.140313,0.003 h 0.0026 c 0.141573,0 0.257407,-0.11583 0.257407,-0.2574 0,-0.14158 -0.115834,-0.25741 -0.257407,-0.25741 h -0.0026 l -0.882906,-0.003 -0.0051,-3.76586 h 0.888054 c 0.141574,0 0.257408,-0.11584 0.257408,-0.25741 0,-0.14157 -0.115834,-0.25741 -0.257408,-0.25741 z"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:'Manjari Bold';fill:#616161;fill-opacity:1;stroke-width:0.04393082"
-         id="path13" />
-      <path
-         d="m 82.34212,140.52814 c 0,0.0206 0.0051,0.0566 0.01544,0.0772 l 1.029629,2.33211 c 0.02574,0.0592 0.100388,0.10811 0.16474,0.10811 0.06435,0 0.139,-0.0489 0.164741,-0.10811 l 1.029628,-2.32439 c 0.0103,-0.0206 0.01802,-0.0541 0.01802,-0.0746 0,-0.10039 -0.0798,-0.18018 -0.180185,-0.18018 -0.06693,0 -0.141574,0.0515 -0.167315,0.11068 l -0.862314,1.95115 -0.867462,-1.96144 c -0.02574,-0.0618 -0.09781,-0.11069 -0.16474,-0.11069 -0.100389,0 -0.180185,0.0824 -0.180185,0.18019 z"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:Manjari;fill:#616161;fill-opacity:1;stroke-width:0.04393082"
-         id="path15" />
-      <path
-         d="m 86.204943,139.42386 h -1.145462 c -0.141574,0 -0.257407,0.11583 -0.257407,0.25741 0,0.14157 0.115833,0.2574 0.257407,0.2574 h 0.888055 l -0.0051,3.76587 -0.882907,0.003 h -0.0026 c -0.141574,0 -0.257407,0.11584 -0.257407,0.25741 0,0.14157 0.115833,0.25741 0.257407,0.25741 h 0.0026 l 1.140314,-0.003 c 0.141574,0 0.257407,-0.11583 0.257407,-0.2574 l 0.0051,-4.28068 c 0,-0.14158 -0.115833,-0.25741 -0.257407,-0.25741 z"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Manjari;-inkscape-font-specification:'Manjari Bold';fill:#616161;fill-opacity:1;stroke-width:0.04393082"
-         id="path17" />
-    </g>
+<svg width="16" height="16" version="1.1" viewBox="0 0 4.2333 4.2333" xmlns="http://www.w3.org/2000/svg">
+ <g transform="translate(-80.642 -140.5)">
+  <g transform="matrix(.73024 0 0 .73024 21.745 39.052)" fill="#616161" stroke-width=".043931" aria-label="[v]">
+   <path d="m80.899 139.43c-0.14157 0-0.25741 0.11584-0.25741 0.25741l0.0051 4.2807c0 0.14157 0.11583 0.25741 0.25741 0.25741l1.1403 3e-3h0.0026c0.14157 0 0.25741-0.11583 0.25741-0.2574 0-0.14158-0.11583-0.25741-0.25741-0.25741h-0.0026l-0.88291-3e-3 -0.0051-3.7659h0.88805c0.14157 0 0.25741-0.11584 0.25741-0.25741s-0.11583-0.25741-0.25741-0.25741z"/>
+   <path d="m82.342 140.53c0 0.0206 0.0051 0.0566 0.01544 0.0772l1.0296 2.3321c0.02574 0.0592 0.10039 0.10811 0.16474 0.10811 0.06435 0 0.139-0.0489 0.16474-0.10811l1.0296-2.3244c0.0103-0.0206 0.01802-0.0541 0.01802-0.0746 0-0.10039-0.0798-0.18018-0.18018-0.18018-0.06693 0-0.14157 0.0515-0.16732 0.11068l-0.86231 1.9512-0.86746-1.9614c-0.02574-0.0618-0.09781-0.11069-0.16474-0.11069-0.10039 0-0.18018 0.0824-0.18018 0.18019z"/>
+   <path d="m86.205 139.42h-1.1455c-0.14157 0-0.25741 0.11583-0.25741 0.25741 0 0.14157 0.11583 0.2574 0.25741 0.2574h0.88806l-0.0051 3.7659-0.88291 3e-3h-0.0026c-0.14157 0-0.25741 0.11584-0.25741 0.25741s0.11583 0.25741 0.25741 0.25741h0.0026l1.1403-3e-3c0.14157 0 0.25741-0.11583 0.25741-0.2574l0.0051-4.2807c0-0.14158-0.11583-0.25741-0.25741-0.25741z"/>
   </g>
+ </g>
 </svg>


### PR DESCRIPTION
This should fix #376.

The voila icons stopped showing in JupyterLab 1.1.

This change optimizes the svg files and sets the width and height to `16` (same as the core icons).

![image](https://user-images.githubusercontent.com/591645/64333109-2c053300-cfd6-11e9-9209-a3b3cffe2321.png)
